### PR TITLE
Add post-merge hook to sync README version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It's a mouthful, is what it is. Let's go with "MEGS for Foundry."
 
 This is a fan-created implementation of the Mayfair Exponential Gaming System, whose core mechanics were used in games such as DC Heroes, Underground, and Blood of Heroes. The core mechanics of the DC Heroes / Underground / Blood of Heroes games were dubbed "MEGS" by its fans, short for ["Mayfair Eponential Gaming System."](https://en.wikipedia.org/wiki/Mayfair_Exponential_Game_System) This was an informal name, never trademarked.
 
-The current version (0.7.0) of MEGS for Foundry has basic character sheets, some die rolling, outcome resolution, and a generic skill tree. It allows you to create heroes, villains, NPCs, powers, gadgets, character traits, power modifications, etc. It's very much a skeleton for running games featuring any superheroes (or villains; I don't discriminate) you want using MEGS at a level similar to DC Heroes 3rd Edition or Blood of Heroes - if you enter your own Powers, Advantages, Drawbacks, Bonuses, Limitations, etc.
+The current version (1.0.0) of MEGS for Foundry has basic character sheets, some die rolling, outcome resolution, and a generic skill tree. It allows you to create heroes, villains, NPCs, powers, gadgets, character traits, power modifications, etc. It's very much a skeleton for running games featuring any superheroes (or villains; I don't discriminate) you want using MEGS at a level similar to DC Heroes 3rd Edition or Blood of Heroes - if you enter your own Powers, Advantages, Drawbacks, Bonuses, Limitations, etc.
 
 It's also a work in progress. I basically tackled it on a whim to teach myself to code the Foundry framework. I will try very hard to make any changes backward compatible so that you can use any characters or items you create after later versions, but... not promising anything until we get to version 1.0.0.
 
@@ -44,7 +44,7 @@ To use compendium items:
 
 ### Do you have future plans?
 
-Do I ever! MEGS for Foundry is currently sitting at **version 0.7.0**.
+Do I ever! MEGS for Foundry is currently sitting at **version 1.0.0**.
 
 (Note that everything below is subject to change.)
 

--- a/scripts/hooks/post-merge
+++ b/scripts/hooks/post-merge
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Post-merge hook: Update README.md version references to match system.json
+
+VERSION=$(sed -n 's/.*"version": "\([0-9]*\.[0-9]*\.[0-9]*\)".*/\1/p' system.json | head -1)
+
+if [ -z "$VERSION" ]; then
+    echo "post-merge: Could not extract version from system.json"
+    exit 0
+fi
+
+if [ ! -f "README.md" ]; then
+    exit 0
+fi
+
+# Update "current version (X.Y.Z)" references
+sed -i -E "s/current version \([0-9]+\.[0-9]+\.[0-9]+\)/current version ($VERSION)/" README.md
+
+# Update "currently sitting at **version X.Y.Z**" references
+sed -i -E "s/currently sitting at \*\*version [0-9]+\.[0-9]+\.[0-9]+\*\*/currently sitting at **version $VERSION**/" README.md
+
+# If README changed, commit the update
+if ! git diff --quiet README.md 2>/dev/null; then
+    git add README.md
+    git commit -m "Update README version references to $VERSION"
+    echo "post-merge: Updated README.md version references to $VERSION"
+else
+    echo "post-merge: README.md version references already at $VERSION"
+fi


### PR DESCRIPTION
## Summary
- Adds a tracked git hook (`scripts/hooks/post-merge`) that automatically updates README.md version references to match `system.json` after every merge
- Updates stale README version references from 0.7.0 to 1.0.0
- Repo configured with `core.hooksPath=scripts/hooks` so the hook is version-controlled

## Note
After cloning, run `git config core.hooksPath scripts/hooks` to enable the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)