### PR TITLE
Remove trailing slash from download URL

### DIFF
--- a/system.json
+++ b/system.json
@@ -116,7 +116,7 @@
     ],
     "socket": false,
     "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.0-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.0-Release/",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.0-Release",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary
- Removes trailing `/` from the `download` URL in `system.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)