### PR TITLE
Wrap switch-case lexical declaration in a block

### DIFF
--- a/module/helpers/effects.mjs
+++ b/module/helpers/effects.mjs
@@ -23,7 +23,7 @@ export async function onManageActiveEffect(event, owner) {
             ]);
         case 'edit':
             return effect.sheet.render(true);
-        case 'delete':
+        case 'delete': {
             const confirmed = await Dialog.confirm({
                 title: `Delete Active Effect: ${effect.name}`,
                 content: `<p style="font-family: Helvetica, Arial, sans-serif;"><strong>Are You Sure?</strong> This item will be permanently deleted and cannot be recovered.</p>`,
@@ -36,6 +36,7 @@ export async function onManageActiveEffect(event, owner) {
                 return effect.delete();
             }
             break;
+        }
         case 'toggle':
             return effect.update({ disabled: !effect.disabled });
     }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/216-wrap-switch-case-declaration-in-block/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/216-wrap-switch-case-declaration-in-block/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/216-wrap-switch-case-declaration-in-block",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary
- Wraps the `case 'delete'` body in `module/helpers/effects.mjs` with braces to scope the `const confirmed` declaration to that case block
- Prevents potential `ReferenceError` (temporal dead zone) if future cases declare similarly-named bindings

Fixes #216