### PR TITLE
Add workflow to auto-close linked issues on PR merge

### DIFF
--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -1,0 +1,42 @@
+name: Close linked issues on PR merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const issueNumbers = new Set();
+            let match;
+            while ((match = pattern.exec(body)) !== null) {
+              issueNumbers.add(parseInt(match[1], 10));
+            }
+            for (const issueNumber of issueNumbers) {
+              try {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  state: 'closed',
+                  state_reason: 'completed'
+                });
+                console.log(`Closed issue #${issueNumber}`);
+              } catch (err) {
+                console.log(`Failed to close issue #${issueNumber}: ${err.message}`);
+              }
+            }
+            if (issueNumbers.size === 0) {
+              console.log('No linked issues found in PR body');
+            }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/216-auto-close-issues-on-merge/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/216-auto-close-issues-on-merge/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/216-auto-close-issues-on-merge",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that fires on PR merge to **any** branch
- Parses the PR body for `Fixes #NNN`, `Closes #NNN`, `Resolves #NNN` (and their variants)
- Closes the matched issues via the GitHub API with state_reason `completed`
- Solves the limitation where GitHub's built-in keyword auto-close only works for the default branch (main)