### PR TITLE
Replace hasOwnProperty calls with Object.hasOwn

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -177,9 +177,9 @@ export class MEGSActor extends Actor {
         // Get all powers and skills (subskills no longer have costs)
         const itemsWithCosts = this.items.filter(item =>
             (item.type === MEGS.itemTypes.power || item.type === MEGS.itemTypes.skill) &&
-            item.system.hasOwnProperty('baseCost') &&
-            item.system.hasOwnProperty('factorCost') &&
-            item.system.hasOwnProperty('aps')
+            Object.hasOwn(item.system, 'baseCost') &&
+            Object.hasOwn(item.system, 'factorCost') &&
+            Object.hasOwn(item.system, 'aps')
         );
 
         itemsWithCosts.forEach(item => {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1044,8 +1044,8 @@ export class MEGSItem extends Item {
             this._calculateGadgetPointBudget();
         }
         // Calculate total cost for powers, skills, advantages, drawbacks (but not gadgets or subskills)
-        else if (systemData.hasOwnProperty('baseCost')) {
-            if (systemData.hasOwnProperty('factorCost') && systemData.hasOwnProperty('aps')) {
+        else if (Object.hasOwn(systemData, 'baseCost')) {
+            if (Object.hasOwn(systemData, 'factorCost') && Object.hasOwn(systemData, 'aps')) {
                 // Subskills don't have costs - skip validation and calculation for them
                 // Only validate factorCost for actual powers and skills
                 if (this.type !== MEGS.itemTypes.subskill &&

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -303,7 +303,7 @@ export class MEGSItemSheet extends ItemSheet {
                     const powerName = itemId.replace('virtual-power-', '');
                     const powerAPs = foundry.utils.duplicate(this.object.system.powerAPs || {});
 
-                    if (powerAPs.hasOwnProperty(powerName)) {
+                    if (Object.hasOwn(powerAPs, powerName)) {
                         powerAPs[powerName] = (powerAPs[powerName] || 0) + 1;
                         await this.object.update({ 'system.powerAPs': powerAPs });
                         this.render(false);
@@ -313,10 +313,10 @@ export class MEGSItemSheet extends ItemSheet {
                     const skillData = foundry.utils.duplicate(this.object.system.skillData || {});
                     const subskillData = foundry.utils.duplicate(this.object.system.subskillData || {});
 
-                    if (skillData.hasOwnProperty(skillName)) {
+                    if (Object.hasOwn(skillData, skillName)) {
                         skillData[skillName] = (skillData[skillName] || 0) + 1;
                         await this.object.update({ 'system.skillData': skillData });
-                    } else if (subskillData.hasOwnProperty(skillName)) {
+                    } else if (Object.hasOwn(subskillData, skillName)) {
                         subskillData[skillName] = (subskillData[skillName] || 0) + 1;
                         await this.object.update({ 'system.subskillData': subskillData });
                     }
@@ -346,7 +346,7 @@ export class MEGSItemSheet extends ItemSheet {
                     const powerName = itemId.replace('virtual-power-', '');
                     const powerAPs = foundry.utils.duplicate(this.object.system.powerAPs || {});
 
-                    if (powerAPs.hasOwnProperty(powerName) && (powerAPs[powerName] || 0) > 0) {
+                    if (Object.hasOwn(powerAPs, powerName) && (powerAPs[powerName] || 0) > 0) {
                         powerAPs[powerName] = (powerAPs[powerName] || 0) - 1;
                         await this.object.update({ 'system.powerAPs': powerAPs });
                         this.render(false);
@@ -356,11 +356,11 @@ export class MEGSItemSheet extends ItemSheet {
                     const skillData = foundry.utils.duplicate(this.object.system.skillData || {});
                     const subskillData = foundry.utils.duplicate(this.object.system.subskillData || {});
 
-                    if (skillData.hasOwnProperty(skillName) && (skillData[skillName] || 0) > 0) {
+                    if (Object.hasOwn(skillData, skillName) && (skillData[skillName] || 0) > 0) {
                         skillData[skillName] = (skillData[skillName] || 0) - 1;
                         await this.object.update({ 'system.skillData': skillData });
                         this.render(false);
-                    } else if (subskillData.hasOwnProperty(skillName) && (subskillData[skillName] || 0) > 0) {
+                    } else if (Object.hasOwn(subskillData, skillName) && (subskillData[skillName] || 0) > 0) {
                         subskillData[skillName] = (subskillData[skillName] || 0) - 1;
                         await this.object.update({ 'system.subskillData': subskillData });
                         this.render(false);

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/217-safe-hasownproperty-calls/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/217-safe-hasownproperty-calls/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/217-safe-hasownproperty-calls",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary
- Replaces 12 direct `.hasOwnProperty()` calls with `Object.hasOwn()` (ES2022+) across 3 files
- Prevents potential `TypeError` on objects with null prototypes or shadowed `hasOwnProperty`
- Files changed: `module/documents/actor.mjs`, `module/documents/item.mjs`, `module/sheets/item-sheet.mjs`

Fixes #217