### PR TITLE
Clean up mechanical lint findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # CHANGELOG
 
+## 1.0.1
+
+### Enhancements
+
+- Alphabetized advantages and drawbacks on character builder sheet
+- Added post-merge hook to sync README version references automatically
+- Added post-checkout hook to auto-update system.json branch URLs on branch switch
+- Added GitHub Action to sync system.json URLs on push to non-main branches
+- Added GitHub Action to auto-close linked issues when PRs are merged to any branch
+
+### Bug Fixes
+
+- Fixed `ReferenceError` crash when selecting multiple targets — `localize()` replaced with `game.i18n.localize()` (issue #215)
+- Fixed `ReferenceError` in `compare` Handlebars helper — added missing `options` parameter (issue #215)
+- Fixed trailing slash in system.json download URL that prevented Foundry from resolving the package
+
+### Code Quality
+
+- Configured ESLint and Stylelint with project-specific rules and added lint CI workflow (issue #214)
+- Wrapped switch-case lexical declaration in a block to prevent temporal dead zone issues (issue #216)
+- Replaced 12 direct `.hasOwnProperty()` calls with `Object.hasOwn()` across actor, item, and item-sheet modules (issue #217)
+- Cleaned up 249 lint findings across 16 files — `prefer-const`, `quotes`, `indent`, brace-style, unused variables/imports, URL quoting, hex shorthand (issue #218)
+- Replaced 37 global `parseInt()` calls with `Number.parseInt()` across 6 modules for consistency (issue #218)
+
 ## 0.4.0 (May 15, 2024)
 
 - Officially entered beta with a very barebones system

--- a/module/__mocks__/foundry.mjs
+++ b/module/__mocks__/foundry.mjs
@@ -1,4 +1,3 @@
-/* global jest */
 /* eslint-env jest */
 import { MEGS } from '../helpers/config.mjs';
 import { jest } from '@jest/globals';
@@ -463,10 +462,8 @@ global.mergeObject = function (
     if (!inplace && _d === 0) original = global.duplicate(original);
 
     // Enforce object expansion at depth 0
-    if (_d === 0 && Object.keys(original).some((k) => /\./.test(k)))
-        original = global.expandObject(original);
-    if (_d === 0 && Object.keys(other).some((k) => /\./.test(k)))
-        other = global.expandObject(other);
+    if (_d === 0 && Object.keys(original).some((k) => /\./.test(k))) { original = global.expandObject(original); }
+    if (_d === 0 && Object.keys(other).some((k) => /\./.test(k))) { other = global.expandObject(other); }
 
     // Iterate over the other object
     for (let [k, v] of Object.entries(other)) {
@@ -541,11 +538,11 @@ global.renderTemplate = async function (template, data) {};
  * Foundry namespaced APIs (V13+)
  */
 global.foundry = {
-  applications: {
-    handlebars: {
-      renderTemplate: async function(template, data) {  }
+    applications: {
+        handlebars: {
+            renderTemplate: async function (template, data) { }
+        }
     }
-  }
 };
 
 /**

--- a/module/__mocks__/roll.mjs
+++ b/module/__mocks__/roll.mjs
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 import { jest } from '@jest/globals';
-import { log, error } from 'console'; // jest overrides console; use these instead
 
 /**
  * Mocks for Foundry's Roll class

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -195,7 +195,7 @@ export default class MEGSCombat extends Combat {
      */
     _processHeroPointsEntry(form) {
         return {
-            hpSpentInitiative: parseInt(form.hpSpentInitiative.value) || 0,
+            hpSpentInitiative: Number.parseInt(form.hpSpentInitiative.value) || 0,
         };
     }
 }

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -267,8 +267,8 @@ export class MegsTableRolls {
         }
         if (combatManeuverKey) {
             const combatManeuver = CONFIG.combatManeuvers[combatManeuverKey];
-            ovColumnShifts += parseInt(combatManeuver.ovShifts);
-            rvColumnShifts += parseInt(combatManeuver.rvShifts);
+            ovColumnShifts += Number.parseInt(combatManeuver.ovShifts);
+            rvColumnShifts += Number.parseInt(combatManeuver.rvShifts);
         }
         if (resultColumnShifts) {
             rvColumnShifts += resultColumnShifts;
@@ -277,7 +277,7 @@ export class MegsTableRolls {
         /**********************************
          * ACTION TABLE
          **********************************/
-        const avAdjusted = parseInt(this.actionValue) + parseInt(hpSpentAV);
+        const avAdjusted = Number.parseInt(this.actionValue) + Number.parseInt(hpSpentAV);
 
         let avInfo = '';
         // Only show tooltip if there's additional information beyond base value
@@ -366,11 +366,11 @@ export class MegsTableRolls {
 
         let avRollTotal = 0;
         dice.forEach((die) => {
-            avRollTotal = avRollTotal + parseInt(die);
+            avRollTotal = avRollTotal + Number.parseInt(die);
         });
         resultData.rollTotal = avRollTotal;
 
-        if (parseInt(dice[dice.length - 2]) === 1 && parseInt(dice[dice.length - 1]) === 1) {
+        if (Number.parseInt(dice[dice.length - 2]) === 1 && Number.parseInt(dice[dice.length - 1]) === 1) {
             // dice are both 1s
             resultData.result = game.i18n.localize('MEGS.Double1s');
             await this._showRollResultInChat(resultData, avRoll, ShowResultCall.DOUBLE_1S);
@@ -419,7 +419,7 @@ export class MegsTableRolls {
             // Show combat maneuver contribution
             if (combatManeuverKey) {
                 const combatManeuver = CONFIG.combatManeuvers[combatManeuverKey];
-                const maneuverShifts = parseInt(combatManeuver.rvShifts);
+                const maneuverShifts = Number.parseInt(combatManeuver.rvShifts);
                 if (maneuverShifts !== 0) {
                     shiftExplanation +=
                         '    <tr>' +
@@ -559,8 +559,8 @@ export class MegsTableRolls {
             } else if (currentRoll.result && typeof currentRoll.result === 'string') {
                 // Fallback for mocks or legacy: parse the result string
                 const rolledDice = currentRoll.result.split(' + ');
-                die1 = parseInt(rolledDice[0]);
-                die2 = parseInt(rolledDice[1]);
+                die1 = Number.parseInt(rolledDice[0]);
+                die2 = Number.parseInt(rolledDice[1]);
             } else {
                 // Ultimate fallback: use mock dice values or defaults
                 die1 = (currentRoll.dice && currentRoll.dice[0] && currentRoll.dice[0].results) ? currentRoll.dice[0].results[0] : 1;
@@ -693,16 +693,16 @@ export class MegsTableRolls {
      */
     _processOpposingValuesEntry(form) {
         return {
-            actionValue: parseInt(form.actionValue?.value) || 0,
-            effectValue: parseInt(form.effectValue?.value) || 0,
-            opposingValue: parseInt(form.opposingValue?.value) || 0,
-            resistanceValue: parseInt(form.resistanceValue?.value) || 0,
-            hpSpentAV: parseInt(form.hpSpentAV.value) || 0,
-            hpSpentEV: parseInt(form.hpSpentEV.value) || 0,
-            hpSpentRV: parseInt(form.hpSpentRV.value) || 0,
-            hpSpentOV: parseInt(form.hpSpentOV.value) || 0,
+            actionValue: Number.parseInt(form.actionValue?.value) || 0,
+            effectValue: Number.parseInt(form.effectValue?.value) || 0,
+            opposingValue: Number.parseInt(form.opposingValue?.value) || 0,
+            resistanceValue: Number.parseInt(form.resistanceValue?.value) || 0,
+            hpSpentAV: Number.parseInt(form.hpSpentAV.value) || 0,
+            hpSpentEV: Number.parseInt(form.hpSpentEV.value) || 0,
+            hpSpentRV: Number.parseInt(form.hpSpentRV.value) || 0,
+            hpSpentOV: Number.parseInt(form.hpSpentOV.value) || 0,
             combatManeuver: form.combatManeuver.value,
-            resultColumnShifts: parseInt(form.resultColumnShiftsInput.value) || 0,
+            resultColumnShifts: Number.parseInt(form.resultColumnShiftsInput.value) || 0,
             isUnskilled: (form.isUnskilled && form.isUnskilled.checked) || false,
         };
     }

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -46,7 +46,7 @@ export class RollValues {
         this.opposingValue = opposingValue;
         this.effectValue = effectValue;
         this.resistanceValue = resistanceValue;
-        this.rollFormula = rollFormula ? rollFormula : '1d10 + 1d10';
+        this.rollFormula = rollFormula || '1d10 + 1d10';
         this.unskilled = unskilled || false;
     }
 }
@@ -342,7 +342,7 @@ export class MegsTableRolls {
         await avRoll.evaluate();
 
         let dice = [];
-        let resultData = {
+        const resultData = {
             result: '',
             actionValue: avAdjusted,
             actionValueInfo: avInfo,
@@ -454,8 +454,6 @@ export class MegsTableRolls {
         /**********************************
          * RESULT TABLE
          **********************************/
-        const resultTable = CONFIG.tables.resultTable;
-
         // get effect value column  index
         const evAdjusted = this.effectValue + hpSpentEV;
         const evIndex = this._getRangeIndex(evAdjusted);
@@ -469,7 +467,7 @@ export class MegsTableRolls {
         // apply shifts
         // Column Shifts on the Result Table are made to the left, decreasing numbers in the Resistance Value row,
         // but increasing the number of Result APs within the Table itself
-        let shiftedRvIndex = rvIndex - columnShifts;
+        const shiftedRvIndex = rvIndex - columnShifts;
         if (shiftedRvIndex <= 0) {
             // calculate column shifts that push past the 0 column
             // If the result is in the +1 Column, add 1 AP to your Result APs for every time you shift into this Column.
@@ -527,14 +525,14 @@ export class MegsTableRolls {
      * @returns
      */
     async _rollDice(data, initialRoll) {
-        let dice = [];
+        const dice = [];
         let stopRolling = false;
         if (data) {
             if (data.columnShifts) {
-                data['isOneColumnShift'] = data.columnShifts === 1;
+                data.isOneColumnShift = data.columnShifts === 1;
             } else {
                 data.columnShifts = 0;
-                data['isOneColumnShift'] = false;
+                data.isOneColumnShift = false;
             }
         }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -17,9 +17,9 @@ export class MEGSActor extends Actor {
     async _getSkills() {
         const skillsJson = await _loadData('systems/megs/assets/data/skills.json');
 
-        let skills = [];
-        let subskills = [];
-        for (let i of skillsJson) {
+        const skills = [];
+        const subskills = [];
+        for (const i of skillsJson) {
             i.img = i.img
                 ? 'systems/megs/assets/images/icons/skillls/' + i.img
                 : 'systems/megs/assets/images/icons/skillls/skill.png';
@@ -30,7 +30,7 @@ export class MEGSActor extends Actor {
             skills.push(item);
 
             if (i.system.subskills) {
-                for (let j of i.system.subskills) {
+                for (const j of i.system.subskills) {
                     const subskillObj = {
                         name: j.name,
                         type: 'subskill',
@@ -56,12 +56,12 @@ export class MEGSActor extends Actor {
 
         this.updateSource({ items: skills });
 
-        let actorSkills = {};
+        const actorSkills = {};
         this.items.forEach((skill) => {
             actorSkills[skill.name] = skill._id;
         });
 
-        for (let i of subskills) {
+        for (const i of subskills) {
             i.system.parent = actorSkills[i.system.linkedSkill];
         }
         this.updateSource({ items: subskills });
@@ -130,6 +130,7 @@ export class MEGSActor extends Actor {
             this.system.creationBudget = { base: 450 };
         }
     }
+
     /**
      * @override
      * Augment the actor source data with additional dynamic data. Typically,
@@ -246,18 +247,18 @@ export class MEGSActor extends Actor {
 
         if (attributes) {
             // Physical attributes
-            attributesCost += MEGS.getAPCost(attributes.dex?.value ?? 0, 7) || 0;  // DEX is FC 7
-            attributesCost += MEGS.getAPCost(attributes.str?.value ?? 0, 6) || 0;  // STR is FC 6
+            attributesCost += MEGS.getAPCost(attributes.dex?.value ?? 0, 7) || 0; // DEX is FC 7
+            attributesCost += MEGS.getAPCost(attributes.str?.value ?? 0, 6) || 0; // STR is FC 6
             attributesCost += MEGS.getAPCost(attributes.body?.value ?? 0, 6) || 0; // BODY is FC 6
 
             // Mental attributes
-            attributesCost += MEGS.getAPCost(attributes.int?.value ?? 0, 7) || 0;  // INT is FC 7
+            attributesCost += MEGS.getAPCost(attributes.int?.value ?? 0, 7) || 0; // INT is FC 7
             attributesCost += MEGS.getAPCost(attributes.will?.value ?? 0, 6) || 0; // WILL is FC 6
             attributesCost += MEGS.getAPCost(attributes.mind?.value ?? 0, 6) || 0; // MIND is FC 6
 
             // Mystical attributes
-            attributesCost += MEGS.getAPCost(attributes.infl?.value ?? 0, 7) || 0;  // INFL is FC 7
-            attributesCost += MEGS.getAPCost(attributes.aura?.value ?? 0, 6) || 0;  // AURA is FC 6
+            attributesCost += MEGS.getAPCost(attributes.infl?.value ?? 0, 7) || 0; // INFL is FC 7
+            attributesCost += MEGS.getAPCost(attributes.aura?.value ?? 0, 6) || 0; // AURA is FC 6
             attributesCost += MEGS.getAPCost(attributes.spirit?.value ?? 0, 6) || 0; // SPIRIT is FC 6
         }
 
@@ -437,26 +438,19 @@ export class MEGSActor extends Actor {
     /**
      * Prepare hero roll data.
      */
-    _getHeroRollData(data) {
-        if (this.type !== MEGS.characterTypes.hero) return;
+    _getHeroRollData(data) { // eslint-disable-line no-unused-vars
+    }
+
+    /**
+     * Prepare villain roll data.
+     */
+    _getVillainRollData(data) { // eslint-disable-line no-unused-vars
     }
 
     /**
      * Prepare NPC roll data.
      */
-    _getVillainRollData(data) {
-        if (this.type !== MEGS.characterTypes.villain) return;
-
-        // Process additional NPC data here.
-    }
-
-    /**
-     * Prepare NPC roll data.
-     */
-    _getNpcRollData(data) {
-        if (this.type !== MEGS.characterTypes.npc) return;
-
-        // Process additional NPC data here.
+    _getNpcRollData(data) { // eslint-disable-line no-unused-vars
     }
 }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1168,8 +1168,8 @@ export class MEGSItem extends Item {
      */
     rollMegs() {
         // for powers, AV and EV are typically APs of power
-        const actionValue = parseInt(this.system.aps);
-        const effectValue = parseInt(this.system.aps);
+        const actionValue = Number.parseInt(this.system.aps);
+        const effectValue = Number.parseInt(this.system.aps);
         let opposingValue = 0;
         let resistanceValue = 0;
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -8,11 +8,6 @@ import { Utils } from '../utils.js';
  */
 export class MEGSItem extends Item {
     /** @override */
-    constructor(data, context) {
-        super(data, context);
-    }
-
-    /** @override */
     toObject(source = true) {
         const data = super.toObject(source);
 
@@ -43,7 +38,7 @@ export class MEGSItem extends Item {
                     console.log(`[MEGS] Found ${childItems.length} child items to serialize`);
                 }
 
-                for (let item of childItems) {
+                for (const item of childItems) {
                     if (item.type === MEGS.itemTypes.skill) {
                         skillData[item.name] = item.system.aps;
                         skillBaseCosts[item.name] = item.system.baseCost || 0;
@@ -120,10 +115,10 @@ export class MEGSItem extends Item {
                 // Standalone gadget - ensure virtual data is preserved during drag
                 if (game.settings.get('megs', 'debugLogging')) {
                     console.log(`[MEGS] toObject() called for standalone gadget ${this.name}`);
-                    console.log(`[MEGS] Preserving powerAPs:`, Object.keys(this.system.powerAPs || {}).length);
-                    console.log(`[MEGS] Preserving skillData:`, Object.keys(this.system.skillData || {}).length);
-                    console.log(`[MEGS] powerAPs data:`, this.system.powerAPs);
-                    console.log(`[MEGS] skillData data:`, this.system.skillData);
+                    console.log('[MEGS] Preserving powerAPs:', Object.keys(this.system.powerAPs || {}).length);
+                    console.log('[MEGS] Preserving skillData:', Object.keys(this.system.skillData || {}).length);
+                    console.log('[MEGS] powerAPs data:', this.system.powerAPs);
+                    console.log('[MEGS] skillData data:', this.system.skillData);
                 }
 
                 // Store in FLAGS during drag - Foundry strips system data when creating on actors
@@ -168,9 +163,9 @@ export class MEGSItem extends Item {
         if (this.type === MEGS.itemTypes.gadget && data.flags?.megs?._transferData) {
             const transferData = data.flags.megs._transferData;
             if (game.settings.get('megs', 'debugLogging')) {
-                console.log(`[MEGS] _preCreate: Found transfer data in creation data`);
-                console.log(`[MEGS] _preCreate powerAPs:`, transferData.powerAPs);
-                console.log(`[MEGS] _preCreate skillData:`, transferData.skillData);
+                console.log('[MEGS] _preCreate: Found transfer data in creation data');
+                console.log('[MEGS] _preCreate powerAPs:', transferData.powerAPs);
+                console.log('[MEGS] _preCreate skillData:', transferData.skillData);
             }
 
             // Store in a global temporary cache that _onCreate can access
@@ -180,7 +175,7 @@ export class MEGSItem extends Item {
             globalThis.MEGS_TRANSFER_CACHE[cacheKey] = transferData;
 
             if (game.settings.get('megs', 'debugLogging')) {
-                console.log(`[MEGS] _preCreate: Stored data in global cache with item ID:`, cacheKey);
+                console.log('[MEGS] _preCreate: Stored data in global cache with item ID:', cacheKey);
             }
         }
     }
@@ -250,24 +245,24 @@ export class MEGSItem extends Item {
                 const cached = globalThis.MEGS_TRANSFER_CACHE[cacheKey];
                 transferData = cached.transferData;
                 if (game.settings.get('megs', 'debugLogging')) {
-                    console.log(`[MEGS] Retrieved transfer data from global cache using options key:`, cacheKey);
-                    console.log(`[MEGS] Cache powerAPs:`, transferData.powerAPs);
-                    console.log(`[MEGS] Cache skillData:`, transferData.skillData);
+                    console.log('[MEGS] Retrieved transfer data from global cache using options key:', cacheKey);
+                    console.log('[MEGS] Cache powerAPs:', transferData.powerAPs);
+                    console.log('[MEGS] Cache skillData:', transferData.skillData);
                 }
                 // Clean up the cache
                 delete globalThis.MEGS_TRANSFER_CACHE[cacheKey];
             } else {
                 if (game.settings.get('megs', 'debugLogging')) {
-                    console.log(`[MEGS] No cache key in options. Key:`, cacheKey);
-                    console.log(`[MEGS] Global cache keys:`, Object.keys(globalThis.MEGS_TRANSFER_CACHE || {}));
+                    console.log('[MEGS] No cache key in options. Key:', cacheKey);
+                    console.log('[MEGS] Global cache keys:', Object.keys(globalThis.MEGS_TRANSFER_CACHE || {}));
                 }
             }
 
             if (transferData) {
                 if (game.settings.get('megs', 'debugLogging')) {
-                    console.log(`[MEGS] Found transfer data in flags, restoring to system`);
-                    console.log(`[MEGS] - powerAPs:`, Object.keys(transferData.powerAPs || {}).length);
-                    console.log(`[MEGS] - skillData:`, Object.keys(transferData.skillData || {}).length);
+                    console.log('[MEGS] Found transfer data in flags, restoring to system');
+                    console.log('[MEGS] - powerAPs:', Object.keys(transferData.powerAPs || {}).length);
+                    console.log('[MEGS] - skillData:', Object.keys(transferData.skillData || {}).length);
                 }
 
                 // Update system fields with transfer data
@@ -295,16 +290,16 @@ export class MEGSItem extends Item {
                     'system.powerIsLinked': this.system.powerIsLinked,
                     'system.powerLinks': this.system.powerLinks,
                     'system.traitData': this.system.traitData,
-                    'flags.megs.-=_transferData': null  // Remove transfer flag
+                    'flags.megs.-=_transferData': null // Remove transfer flag
                 });
                 if (game.settings.get('megs', 'debugLogging')) {
-                    console.log(`[MEGS] Transfer complete, data restored to system`);
+                    console.log('[MEGS] Transfer complete, data restored to system');
                 }
             }
 
             if (game.settings.get('megs', 'debugLogging')) {
-                console.log(`[MEGS] powerAPs keys:`, Object.keys(this.system.powerAPs || {}));
-                console.log(`[MEGS] skillData keys:`, Object.keys(this.system.skillData || {}));
+                console.log('[MEGS] powerAPs keys:', Object.keys(this.system.powerAPs || {}));
+                console.log('[MEGS] skillData keys:', Object.keys(this.system.skillData || {}));
             }
 
             // Gadget owned by actor - create actual skill, power, and trait items
@@ -320,8 +315,8 @@ export class MEGSItem extends Item {
         } else {
             if (game.settings.get('megs', 'debugLogging')) {
                 console.log(`[MEGS] Standalone gadget ${this.name} (${this.id}) created`);
-                console.log(`[MEGS] Existing powerAPs:`, Object.keys(this.system.powerAPs || {}).length);
-                console.log(`[MEGS] Existing skillData:`, Object.keys(this.system.skillData || {}).length);
+                console.log('[MEGS] Existing powerAPs:', Object.keys(this.system.powerAPs || {}).length);
+                console.log('[MEGS] Existing skillData:', Object.keys(this.system.skillData || {}).length);
             }
 
             // Standalone gadget - initialize skillData only if not already populated
@@ -331,12 +326,12 @@ export class MEGSItem extends Item {
 
             if (!hasPowerData && !hasSkillData) {
                 if (game.settings.get('megs', 'debugLogging')) {
-                    console.log(`[MEGS] No existing data found, initializing with defaults`);
+                    console.log('[MEGS] No existing data found, initializing with defaults');
                 }
                 await this._initializeSkillData();
             } else {
                 if (game.settings.get('megs', 'debugLogging')) {
-                    console.log(`[MEGS] Existing data found (from toObject), persisting to database`);
+                    console.log('[MEGS] Existing data found (from toObject), persisting to database');
                 }
                 // Data came from toObject() but needs to be explicitly saved
                 await this.update({
@@ -401,13 +396,13 @@ export class MEGSItem extends Item {
         const skillData = {};
         const subskillData = {};
 
-        for (let skill of skillsJson) {
+        for (const skill of skillsJson) {
             // Initialize skill with 0 APs
             skillData[skill.name] = 0;
 
             // Initialize subskills with 0 APs
             if (skill.system.subskills) {
-                for (let subskill of skill.system.subskills) {
+                for (const subskill of skill.system.subskills) {
                     subskillData[subskill.name] = 0;
                 }
             }
@@ -427,10 +422,10 @@ export class MEGSItem extends Item {
         const subskillData = this.system.subskillData || {};
         const subskillTrainingData = this.system.subskillTrainingData || {};
 
-        let skills = [];
-        let subskills = [];
+        const skills = [];
+        const subskills = [];
 
-        for (let i of skillsJson) {
+        for (const i of skillsJson) {
             const skillImg = i.img
                 ? 'systems/megs/assets/images/icons/skillls/' + i.img
                 : 'systems/megs/assets/images/icons/skillls/skill.png';
@@ -447,7 +442,7 @@ export class MEGSItem extends Item {
             skills.push(item);
 
             if (i.system.subskills) {
-                for (let j of i.system.subskills) {
+                for (const j of i.system.subskills) {
                     const subskillObj = {
                         name: j.name,
                         type: 'subskill',
@@ -475,12 +470,12 @@ export class MEGSItem extends Item {
         const createdSkills = await this.parent.createEmbeddedDocuments('Item', skills);
 
         // Now link subskills to their parent skills
-        let skillMap = {};
+        const skillMap = {};
         createdSkills.forEach((skill) => {
             skillMap[skill.name] = skill.id;
         });
 
-        for (let i of subskills) {
+        for (const i of subskills) {
             i.system.parent = skillMap[i.system.linkedSkill];
         }
 
@@ -504,10 +499,10 @@ export class MEGSItem extends Item {
         // If no powers to add, return early
         if (Object.keys(powerAPs).length === 0) return;
 
-        let powers = [];
+        const powers = [];
 
         // Iterate over power names
-        for (let powerName in powerAPs) {
+        for (const powerName in powerAPs) {
             if (game.settings.get('megs', 'debugLogging')) {
                 console.log(`[MEGS] Adding power: ${powerName}`);
             }
@@ -516,7 +511,7 @@ export class MEGSItem extends Item {
                 type: 'power',
                 img: 'systems/megs/assets/images/icons/power.png',
                 system: {
-                    parent: this.id,  // Set parent to this gadget's ID
+                    parent: this.id, // Set parent to this gadget's ID
                     aps: powerAPs[powerName] || 0,
                     baseCost: powerBaseCosts[powerName] || 0,
                     factorCost: powerFactorCosts[powerName] || 0,
@@ -542,19 +537,19 @@ export class MEGSItem extends Item {
         // If no traits to add, return early
         if (Object.keys(traitData).length === 0) return;
 
-        let traits = [];
+        const traits = [];
 
         // Iterate over trait keys (keys may include timestamp for uniqueness)
-        for (let traitKey in traitData) {
+        for (const traitKey in traitData) {
             const trait = traitData[traitKey];
             const traitObj = {
-                name: trait.name || traitKey,  // Use trait.name if available, fallback to key
+                name: trait.name || traitKey, // Use trait.name if available, fallback to key
                 type: trait.type || 'advantage',
                 img: 'icons/svg/item-bag.svg',
                 system: {
-                    parent: this.id,  // Set parent to this gadget's ID
-                    baseCost: trait.system?.baseCost || trait.baseCost || 0,  // Handle both formats
-                    text: trait.system?.text || trait.text || ''  // Handle both formats
+                    parent: this.id, // Set parent to this gadget's ID
+                    baseCost: trait.system?.baseCost || trait.baseCost || 0, // Handle both formats
+                    text: trait.system?.text || trait.text || '' // Handle both formats
                 }
             };
             traits.push(traitObj);
@@ -844,7 +839,6 @@ export class MEGSItem extends Item {
         super.prepareData();
     }
 
-
     /**
      * @override
      * Augment the item source data with additional dynamic data. Typically,
@@ -978,7 +972,7 @@ export class MEGSItem extends Item {
                             if (item.system.factorCost === undefined || item.system.factorCost === null || item.system.factorCost === 0) {
                                 if (game.settings.get('megs', 'debugLogging')) {
                                     console.error(`  ❌ ${item.name} has invalid factorCost: ${item.system.factorCost} (APs: ${item.system.aps})`);
-                                    console.log(`     Full system data:`, item.system);
+                                    console.log('     Full system data:', item.system);
                                 }
                             }
 
@@ -1022,7 +1016,7 @@ export class MEGSItem extends Item {
                 }
             } else {
                 if (game.settings.get('megs', 'debugLogging')) {
-                    console.log(`  Cannot check child items - parent or parent.items not available`);
+                    console.log('  Cannot check child items - parent or parent.items not available');
                 }
             }
 
@@ -1042,9 +1036,7 @@ export class MEGSItem extends Item {
 
             // Calculate gadget point budget for gadget builder
             this._calculateGadgetPointBudget();
-        }
-        // Calculate total cost for powers, skills, advantages, drawbacks (but not gadgets or subskills)
-        else if (Object.hasOwn(systemData, 'baseCost')) {
+        } else if (Object.hasOwn(systemData, 'baseCost')) {
             if (Object.hasOwn(systemData, 'factorCost') && Object.hasOwn(systemData, 'aps')) {
                 // Subskills don't have costs - skip validation and calculation for them
                 // Only validate factorCost for actual powers and skills
@@ -1147,19 +1139,14 @@ export class MEGSItem extends Item {
             this.type === MEGS.itemTypes.power
         ) {
             this.rollMegs();
-        }
-
-        // If there's no roll data, send a chat message.
-        else if (!this.system.formula) {
+        } else if (!this.system.formula) {
             ChatMessage.create({
                 speaker: speaker,
                 rollMode: rollMode,
                 flavor: label,
                 content: item.system.description ?? '',
             });
-        }
-        // Otherwise, create a roll and send a chat message from it.
-        else {
+        } else {
             // Retrieve roll data.
             const rollData = this.getRollData();
 
@@ -1181,12 +1168,12 @@ export class MEGSItem extends Item {
      */
     rollMegs() {
         // for powers, AV and EV are typically APs of power
-        let actionValue = parseInt(this.system.aps);
-        let effectValue = parseInt(this.system.aps);
+        const actionValue = parseInt(this.system.aps);
+        const effectValue = parseInt(this.system.aps);
         let opposingValue = 0;
         let resistanceValue = 0;
 
-        let targetActor = MegsTableRolls.getTargetActor();
+        const targetActor = MegsTableRolls.getTargetActor();
 
         if (targetActor) {
             let key;

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -118,7 +118,7 @@ MEGS.yesNoOptions = {
  * @param {number} factorCost - The Factor Cost (FC) of the ability (1-10)
  * @returns {number} The Hero Point cost, or 0 if invalid parameters
  */
-MEGS.getAPCost = function(aps, factorCost) {
+MEGS.getAPCost = function (aps, factorCost) {
     // Validate inputs - 0 APs is valid (costs 0), but FC must be 1-10
     if (aps === null || aps === undefined || aps < 0 ||
         factorCost === null || factorCost === undefined || factorCost < 1 || factorCost > 10) {

--- a/module/helpers/effects.mjs
+++ b/module/helpers/effects.mjs
@@ -9,36 +9,36 @@ export async function onManageActiveEffect(event, owner) {
     const li = a.closest('li');
     const effect = li.dataset.effectId ? owner.effects.get(li.dataset.effectId) : null;
     switch (a.dataset.action) {
-        case 'create':
-            return owner.createEmbeddedDocuments('ActiveEffect', [
-                {
-                    name: game.i18n.format('MEGS.New', {
-                        type: game.i18n.localize('MEGS.ActiveEffect'),
-                    }),
-                    icon: 'icons/svg/aura.svg',
-                    origin: owner.uuid,
-                    'duration.rounds': li.dataset.effectType === 'temporary' ? 1 : undefined,
-                    disabled: li.dataset.effectType === 'inactive',
-                },
-            ]);
-        case 'edit':
-            return effect.sheet.render(true);
-        case 'delete': {
-            const confirmed = await Dialog.confirm({
-                title: `Delete Active Effect: ${effect.name}`,
-                content: `<p style="font-family: Helvetica, Arial, sans-serif;"><strong>Are You Sure?</strong> This item will be permanently deleted and cannot be recovered.</p>`,
-                defaultYes: false,
-                options: {
-                    classes: ['megs', 'dialog']
-                }
-            });
-            if (confirmed) {
-                return effect.delete();
+    case 'create':
+        return owner.createEmbeddedDocuments('ActiveEffect', [
+            {
+                name: game.i18n.format('MEGS.New', {
+                    type: game.i18n.localize('MEGS.ActiveEffect'),
+                }),
+                icon: 'icons/svg/aura.svg',
+                origin: owner.uuid,
+                'duration.rounds': li.dataset.effectType === 'temporary' ? 1 : undefined,
+                disabled: li.dataset.effectType === 'inactive',
+            },
+        ]);
+    case 'edit':
+        return effect.sheet.render(true);
+    case 'delete': {
+        const confirmed = await Dialog.confirm({
+            title: `Delete Active Effect: ${effect.name}`,
+            content: '<p style="font-family: Helvetica, Arial, sans-serif;"><strong>Are You Sure?</strong> This item will be permanently deleted and cannot be recovered.</p>',
+            defaultYes: false,
+            options: {
+                classes: ['megs', 'dialog']
             }
-            break;
+        });
+        if (confirmed) {
+            return effect.delete();
         }
-        case 'toggle':
-            return effect.update({ disabled: !effect.disabled });
+        break;
+    }
+    case 'toggle':
+        return effect.update({ disabled: !effect.disabled });
     }
 }
 
@@ -68,7 +68,7 @@ export function prepareActiveEffectCategories(effects) {
     };
 
     // Iterate over active effects, classifying them into categories
-    for (let e of effects) {
+    for (const e of effects) {
         if (e.disabled) categories.inactive.effects.push(e);
         else if (e.isTemporary) categories.temporary.effects.push(e);
         else categories.passive.effects.push(e);

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -49,7 +49,7 @@ Hooks.once('init', function () {
         if (data) {
             CONFIG.tables = data;
         } else {
-            console.error(`[MEGS] Failed to set CONFIG.tables - data is null/undefined`);
+            console.error('[MEGS] Failed to set CONFIG.tables - data is null/undefined');
         }
     });
 
@@ -68,11 +68,11 @@ Hooks.once('init', function () {
             if (data) {
                 CONFIG.combatManeuvers = data;
             } else {
-                console.error(`[MEGS] Failed to load combat maneuvers`);
+                console.error('[MEGS] Failed to load combat maneuvers');
             }
         })
         .catch((error) => {
-            console.error(`[MEGS] Error loading combat maneuvers:`, error);
+            console.error('[MEGS] Error loading combat maneuvers:', error);
         });
 
     _loadData('systems/megs/assets/data/motivations.json')
@@ -80,11 +80,11 @@ Hooks.once('init', function () {
             if (data) {
                 CONFIG.motivations = data;
             } else {
-                console.error(`[MEGS] Failed to load motivations`);
+                console.error('[MEGS] Failed to load motivations');
             }
         })
         .catch((error) => {
-            console.error(`[MEGS] Error loading motivations:`, error);
+            console.error('[MEGS] Error loading motivations:', error);
         });
 
     _loadData('systems/megs/assets/data/skills.json')
@@ -92,11 +92,11 @@ Hooks.once('init', function () {
             if (data) {
                 CONFIG.skills = data;
             } else {
-                console.error(`[MEGS] Failed to load skills`);
+                console.error('[MEGS] Failed to load skills');
             }
         })
         .catch((error) => {
-            console.error(`[MEGS] Error loading skills:`, error);
+            console.error('[MEGS] Error loading skills:', error);
         });
 
     _loadData('systems/megs/assets/data/apCostChart.json')
@@ -104,11 +104,11 @@ Hooks.once('init', function () {
             if (data) {
                 CONFIG.apCostChart = data;
             } else {
-                console.error(`[MEGS] Failed to load AP cost chart`);
+                console.error('[MEGS] Failed to load AP cost chart');
             }
         })
         .catch((error) => {
-            console.error(`[MEGS] Error loading AP cost chart:`, error);
+            console.error('[MEGS] Error loading AP cost chart:', error);
         });
 
     _loadData('systems/megs/assets/data/wealth.json')
@@ -116,11 +116,11 @@ Hooks.once('init', function () {
             if (data) {
                 CONFIG.wealth = data;
             } else {
-                console.error(`[MEGS] Failed to load wealth`);
+                console.error('[MEGS] Failed to load wealth');
             }
         })
         .catch((error) => {
-            console.error(`[MEGS] Error loading wealth:`, error);
+            console.error('[MEGS] Error loading wealth:', error);
         });
 
     // Active Effects are never copied to the Actor,
@@ -219,30 +219,30 @@ Handlebars.registerHelper('isDivisor', function (num1, num2) {
 
 Handlebars.registerHelper('compare', function (v1, operator, v2, options) {
     switch (operator) {
-        case 'eq':
-            return v1 === v2;
-        case '==':
-            return v1 == v2; // eslint-disable-line eqeqeq -- '==' is the operator being tested
-        case '===':
-            return v1 === v2;
-        case '!=':
-            return v1 != v2; // eslint-disable-line eqeqeq -- '!=' is the operator being tested
-        case '!==':
-            return v1 !== v2;
-        case '<':
-            return v1 < v2;
-        case '<=':
-            return v1 <= v2;
-        case '>':
-            return v1 > v2;
-        case '>=':
-            return v1 >= v2;
-        case '&&':
-            return v1 && v2;
-        case '||':
-            return v1 || v2;
-        default:
-            return options.inverse(this);
+    case 'eq':
+        return v1 === v2;
+    case '==':
+        return v1 == v2; // eslint-disable-line eqeqeq -- '==' is the operator being tested
+    case '===':
+        return v1 === v2;
+    case '!=':
+        return v1 != v2; // eslint-disable-line eqeqeq -- '!=' is the operator being tested
+    case '!==':
+        return v1 !== v2;
+    case '<':
+        return v1 < v2;
+    case '<=':
+        return v1 <= v2;
+    case '>':
+        return v1 > v2;
+    case '>=':
+        return v1 >= v2;
+    case '&&':
+        return v1 && v2;
+    case '||':
+        return v1 || v2;
+    default:
+        return options.inverse(this);
     }
 });
 
@@ -254,7 +254,7 @@ Handlebars.registerHelper('trueFalseToYesNo', function (str) {
 // skill-related
 /* -------------------------------------------- */
 Handlebars.registerHelper('getSelectedSkillRange', function (skillName) {
-    for (let i of game.items) {
+    for (const i of game.items) {
         if (i.type === MEGS.itemTypes.skill) {
             if (i.name === skillName) {
                 return i.system.range;
@@ -265,7 +265,7 @@ Handlebars.registerHelper('getSelectedSkillRange', function (skillName) {
 });
 
 Handlebars.registerHelper('getSelectedSkillType', function (skillName) {
-    for (let i of game.items) {
+    for (const i of game.items) {
         if (i.type === MEGS.itemTypes.skill) {
             if (i.name === skillName) {
                 return i.system.type;
@@ -277,7 +277,7 @@ Handlebars.registerHelper('getSelectedSkillType', function (skillName) {
 
 Handlebars.registerHelper('getSelectedSkillLink', function (skillName) {
     if (game.items) {
-        for (let i of game.items) {
+        for (const i of game.items) {
             if (i.type === MEGS.itemTypes.skill) {
                 if (i.name === skillName) {
                     return game.i18n.localize(CONFIG.MEGS.attributes[i.system.link.toLowerCase()]);
@@ -285,7 +285,7 @@ Handlebars.registerHelper('getSelectedSkillLink', function (skillName) {
             }
         }
     } else {
-        console.error(`Returned undefined for game.items!`);
+        console.error('Returned undefined for game.items!');
     }
     return 'N/A';
 });
@@ -565,7 +565,7 @@ Handlebars.registerHelper('getSkillEffectiveFactorCost', function (skill, items)
     // Calculate effective Factor Cost for a skill
     // FC = Base FC - (number of unchecked subskills) - (linking bonus)
     // Minimum FC is always 1
-    let baseFc = skill.system.factorCost || 0;
+    const baseFc = skill.system.factorCost || 0;
     let effectiveFc = baseFc;
 
     // Apply linking reduction (-2, minimum 1)
@@ -713,7 +713,7 @@ Handlebars.registerHelper('getHPSpentTooltip', function (budget) {
     tooltip += `Advantages: ${advantages} HP\n`;
     tooltip += `Drawbacks: ${drawbacks} HP\n`;
     tooltip += `Gadgets: ${gadgets} HP\n`;
-    tooltip += `─────────────────\n`;
+    tooltip += '─────────────────\n';
     tooltip += `Total: ${total} HP`;
 
     return tooltip;
@@ -721,7 +721,7 @@ Handlebars.registerHelper('getHPSpentTooltip', function (budget) {
 
 Handlebars.registerHelper('getEffectiveFactorCost', function (power, items) {
     // Calculate the effective Factor Cost including linking and modifiers
-    let baseFc = power.system.factorCost || 0;
+    const baseFc = power.system.factorCost || 0;
     let effectiveFc = baseFc;
 
     // Apply linking reduction (-2, minimum 1)
@@ -832,7 +832,7 @@ Handlebars.registerHelper('getGadgetDescription', function (gadget) {
     }
 
     // attributes first
-    for (let attributeName in gadget.system.attributes) {
+    for (const attributeName in gadget.system.attributes) {
         if (Object.prototype.hasOwnProperty.call(gadget.system.attributes, attributeName)) {
             const attribute = gadget.system.attributes[attributeName];
             if (attribute.value > 0) {
@@ -853,7 +853,7 @@ Handlebars.registerHelper('getGadgetDescription', function (gadget) {
 
     if (owner && owner.items) {
         // powers
-        for (let i of owner.items) {
+        for (const i of owner.items) {
             if (i.type === MEGS.itemTypes.power && i.system.parent === gadget._id) {
                 if (description) {
                     description += ', ';
@@ -863,7 +863,7 @@ Handlebars.registerHelper('getGadgetDescription', function (gadget) {
         }
 
         // skills
-        for (let i of owner.items) {
+        for (const i of owner.items) {
             if (
                 i.type === MEGS.itemTypes.skill &&
                 i.system.parent === gadget._id &&
@@ -962,11 +962,11 @@ Handlebars.registerHelper('getGadgetCostTooltip', function (gadget) {
                 console.log(`  ${key.toUpperCase()}: base FC=${attr.factorCost}, +reliabilityMod(${reliabilityMod})`);
                 if (attr.alwaysSubstitute) {
                     fc += 2;
-                    console.log(`    +2 for alwaysSubstitute`);
+                    console.log('    +2 for alwaysSubstitute');
                 }
                 if (key === 'body' && (systemData.hasHardenedDefenses === true || systemData.hasHardenedDefenses === 'true')) {
                     fc += 2;
-                    console.log(`    +2 for Hardened Defenses`);
+                    console.log('    +2 for Hardened Defenses');
                 }
                 fc = Math.max(1, fc);
                 const attrCost = MEGS.getAPCost(attr.value, fc) || 0;
@@ -1101,12 +1101,12 @@ Handlebars.registerHelper('getGadgetBudgetTooltip', function (budget) {
     if (skills > 0) tooltip += `Skills: ${skills} HP\n`;
     if (advantages > 0) tooltip += `Advantages: ${advantages} HP\n`;
     if (drawbacks !== 0) tooltip += `Drawbacks: ${drawbacks} HP\n`;
-    tooltip += `─────────────────\n`;
+    tooltip += '─────────────────\n';
     tooltip += `Subtotal: ${totalBeforeBonus} HP\n`;
     // Determine gadget bonus from the actual division
     const gadgetBonus = totalBeforeBonus > 0 && total > 0 ? Math.round(totalBeforeBonus / total) : 4;
     tooltip += `Gadget Bonus: ÷${gadgetBonus}\n`;
-    tooltip += `─────────────────\n`;
+    tooltip += '─────────────────\n';
     tooltip += `Total: ${total} HP`;
 
     return tooltip;
@@ -1289,14 +1289,14 @@ Hooks.once('ready', async function () {
 
                 try {
                     // Get the index (this doesn't load all items, just the index)
-                    console.log(`[MEGS]   Attempting to get index...`);
+                    console.log('[MEGS]   Attempting to get index...');
                     const index = await pack.getIndex();
                     console.log(`[MEGS]   Index retrieved. Items in index: ${index.size}`);
 
                     if (index.size > 0) {
                         // Show first 3 items as sample
                         const sampleItems = Array.from(index.values()).slice(0, 3);
-                        console.log(`[MEGS]   Sample items:`);
+                        console.log('[MEGS]   Sample items:');
                         sampleItems.forEach(item => {
                             console.log(`[MEGS]     - ${item.name} (${item._id}, type: ${item.type})`);
                         });
@@ -1305,7 +1305,7 @@ Hooks.once('ready', async function () {
                     }
                 } catch (error) {
                     console.error(`[MEGS]   *** ERROR loading pack "${pack.metadata.label}":`, error);
-                    console.error(`[MEGS]   Error details:`, error.message, error.stack);
+                    console.error('[MEGS]   Error details:', error.message, error.stack);
                 }
             }
 
@@ -1320,7 +1320,7 @@ Hooks.once('ready', async function () {
 
     // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
     Hooks.on('hotbarDrop', (bar, data, slot) => {
-        let item = fromUuidSync(data.uuid);
+        const item = fromUuidSync(data.uuid);
         if (item && item.system) {
             createMegsMacro(item, slot);
             return false;
@@ -1463,10 +1463,11 @@ function rollItemMacro(uuid) {
     const actorId = uuid.match(/^Actor\.([A-Za-z0-9]+)\.Item\..+/)[1];
     const actor = game.actors.get(actorId);
     const item = actor ? actor.items.find((i) => i.uuid === uuid) : null;
-    if (!item)
+    if (!item) {
         return ui.notifications.warn(
             `Could not find item with UUID ${uuid}. You may need to delete and recreate this macro.`
         );
+    }
 
     // Trigger the item roll
     return item.roll();

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,5 +1,4 @@
 import { MEGS } from '../helpers/config.mjs';
-import { prepareActiveEffectCategories } from '../helpers/effects.mjs';
 import { MegsTableRolls, RollValues } from '../dice.mjs';
 import { Utils } from '../utils.js';
 
@@ -19,7 +18,7 @@ export class MEGSActorSheet extends ActorSheet {
 
     /** @override */
     static get defaultOptions() {
-        let newOptions = super.defaultOptions;
+        const newOptions = super.defaultOptions;
         newOptions.classes = ['megs', 'sheet', 'actor'];
         newOptions.width = 667;
         newOptions.height = 600;
@@ -226,7 +225,7 @@ export class MEGSActorSheet extends ActorSheet {
      */
     _prepareCharacterData(context) {
         // Handle attribute scores.
-        for (let [k, v] of Object.entries(context.system.attributes)) {
+        for (const [k, v] of Object.entries(context.system.attributes)) {
             v.label = game.i18n.localize(CONFIG.MEGS.attributes[k]) ?? k;
         }
 
@@ -413,12 +412,9 @@ export class MEGSActorSheet extends ActorSheet {
         context.items.forEach((i) => {
             i.img = i.img || Item.DEFAULT_ICON;
 
-            // Append to powers
             if (i.type === MEGS.itemTypes.power && !i.system.parent) {
                 powers.push(i);
-            }
-            // Append to skills.
-            else if (i.type === MEGS.itemTypes.skill && !i.system.parent) {
+            } else if (i.type === MEGS.itemTypes.skill && !i.system.parent) {
                 i.subskills = [];
                 if (i.system.aps === 0) {
                     i.unskilled = true;
@@ -428,21 +424,13 @@ export class MEGSActorSheet extends ActorSheet {
                 }
                 i.subskills = [];
                 skills.push(i);
-            }
-            // Append to advantages.
-            else if (i.type === MEGS.itemTypes.advantage && !i.system.parent) {
+            } else if (i.type === MEGS.itemTypes.advantage && !i.system.parent) {
                 advantages.push(i);
-            }
-            // Append to drawbacks.
-            else if (i.type === MEGS.itemTypes.drawback && !i.system.parent) {
+            } else if (i.type === MEGS.itemTypes.drawback && !i.system.parent) {
                 drawbacks.push(i);
-            }
-            // Append to subskills.
-            else if (i.type === MEGS.itemTypes.subskill) {
+            } else if (i.type === MEGS.itemTypes.subskill) {
                 subskills.push(i);
-            }
-            // Append to gadgets; do not show if gadget is owned by another gadget
-            else if (i.type === MEGS.itemTypes.gadget && !i.system.parent) {
+            } else if (i.type === MEGS.itemTypes.gadget && !i.system.parent) {
                 i.ownerId = this.object._id;
                 i.rollable = i.system.effectValue > 0 || i.system.actionValue > 0;
                 gadgets.push(i);
@@ -481,8 +469,8 @@ export class MEGSActorSheet extends ActorSheet {
         const arrays = [powers, skills, advantages, drawbacks, subskills, gadgets];
         arrays.forEach((element) => {
             element.sort(function (a, b) {
-                let textA = a.name.toUpperCase();
-                let textB = b.name.toUpperCase();
+                const textA = a.name.toUpperCase();
+                const textB = b.name.toUpperCase();
                 return textA < textB ? -1 : textA > textB ? 1 : 0;
             });
         });
@@ -573,7 +561,7 @@ export class MEGSActorSheet extends ActorSheet {
 
         // Drag events for macros.
         if (this.actor.isOwner) {
-            let handler = (ev) => this._onDragStart(ev);
+            const handler = (ev) => this._onDragStart(ev);
             html.find('li.item').each((i, li) => {
                 if (li.classList.contains('inventory-header')) return;
                 li.setAttribute('draggable', true);
@@ -611,7 +599,7 @@ export class MEGSActorSheet extends ActorSheet {
             system: data,
         };
         // Remove the type from the dataset since it's in the itemData.type prop.
-        delete itemData.system['type'];
+        delete itemData.system.type;
 
         // Finally, create the item!
         return await Item.create(itemData, { parent: this.actor });
@@ -696,7 +684,7 @@ export class MEGSActorSheet extends ActorSheet {
         const type = item.type.charAt(0).toUpperCase() + item.type.slice(1);
         const confirmed = await Dialog.confirm({
             title: `Delete ${type}: ${item.name}`,
-            content: `<p style="font-family: Helvetica, Arial, sans-serif;"><strong>Are You Sure?</strong> This item will be permanently deleted and cannot be recovered.</p>`,
+            content: '<p style="font-family: Helvetica, Arial, sans-serif;"><strong>Are You Sure?</strong> This item will be permanently deleted and cannot be recovered.</p>',
             defaultYes: false,
             options: {
                 classes: ['megs', 'dialog']
@@ -921,7 +909,7 @@ export class MEGSActorSheet extends ActorSheet {
         let effectValue = 0;
         let resistanceValue = 0;
 
-        let targetActor = MegsTableRolls.getTargetActor();
+        const targetActor = MegsTableRolls.getTargetActor();
         if (targetActor) {
             if (dataset.type === MEGS.rollTypes.attribute) {
                 opposingValue = targetActor.system.attributes[dataset.key].value;
@@ -991,7 +979,7 @@ export class MEGSActorSheet extends ActorSheet {
     _getOwnedItemById(id) {
         let ownedItem;
         const items = this.object.collections.items;
-        for (let i of items) {
+        for (const i of items) {
             if (i._id === id) {
                 ownedItem = i;
                 break;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -904,7 +904,7 @@ export class MEGSActorSheet extends ActorSheet {
         const element = event.currentTarget;
         const dataset = element.dataset;
 
-        let actionValue = parseInt(dataset.value);
+        let actionValue = Number.parseInt(dataset.value);
         let opposingValue = 0;
         let effectValue = 0;
         let resistanceValue = 0;
@@ -934,11 +934,11 @@ export class MEGSActorSheet extends ActorSheet {
             dataset.type === MEGS.itemTypes.skill ||
             dataset.type === MEGS.itemTypes.subskill
         ) {
-            effectValue = parseInt(dataset.value);
+            effectValue = Number.parseInt(dataset.value);
         } else if (dataset.type === MEGS.itemTypes.gadget) {
             // TODO clean all this up; waaaay too complex
-            actionValue = parseInt(dataset.actionvalue);
-            effectValue = parseInt(dataset.effectvalue);
+            actionValue = Number.parseInt(dataset.actionvalue);
+            effectValue = Number.parseInt(dataset.effectvalue);
 
             if (effectValue === 0) {
                 // no EV specified; check attributes

--- a/module/sheets/character-creator-sheet.mjs
+++ b/module/sheets/character-creator-sheet.mjs
@@ -65,10 +65,10 @@ export class MEGSCharacterBuilderSheet extends MEGSActorSheet {
 
         // Ensure wealth values are always numbers (Foundry form handling can convert to string)
         if (context.system.wealth !== undefined && context.system.wealth !== null) {
-            context.system.wealth = parseInt(context.system.wealth);
+            context.system.wealth = Number.parseInt(context.system.wealth);
         }
         if (context.system.wealthYear !== undefined && context.system.wealthYear !== null) {
-            context.system.wealthYear = parseInt(context.system.wealthYear);
+            context.system.wealthYear = Number.parseInt(context.system.wealthYear);
         }
 
         // Debug: Log wealth value in getData
@@ -164,7 +164,7 @@ export class MEGSCharacterBuilderSheet extends MEGSActorSheet {
             const isChecked = ev.currentTarget.checked;
 
             // Store current wealth selection to restore after render
-            const currentWealth = parseInt(this.actor.system.wealth ?? 0);
+            const currentWealth = Number.parseInt(this.actor.system.wealth ?? 0);
             console.log('Checkbox change - current wealth:', currentWealth, 'checked:', isChecked);
 
             // If unchecking, reset year to 1990
@@ -186,10 +186,10 @@ export class MEGSCharacterBuilderSheet extends MEGSActorSheet {
         // Wealth year selection
         html.on('change', '.wealth-year-select', async (ev) => {
             ev.preventDefault();
-            const selectedYear = parseInt(ev.currentTarget.value);
+            const selectedYear = Number.parseInt(ev.currentTarget.value);
 
             // Store current wealth selection to restore after render
-            const currentWealth = parseInt(this.actor.system.wealth ?? 0);
+            const currentWealth = Number.parseInt(this.actor.system.wealth ?? 0);
             console.log('Year change - current wealth:', currentWealth, 'new year:', selectedYear);
 
             await this.actor.update({
@@ -202,7 +202,7 @@ export class MEGSCharacterBuilderSheet extends MEGSActorSheet {
         // Wealth radio button selection
         html.on('change', '.wealth-radio', async (ev) => {
             ev.preventDefault();
-            const selectedAP = parseInt(ev.currentTarget.value);
+            const selectedAP = Number.parseInt(ev.currentTarget.value);
             await this.actor.update({ 'system.wealth': selectedAP });
         });
 

--- a/module/sheets/character-creator-sheet.mjs
+++ b/module/sheets/character-creator-sheet.mjs
@@ -7,7 +7,7 @@ import { MEGSActorSheet } from './actor-sheet.mjs';
 export class MEGSCharacterBuilderSheet extends MEGSActorSheet {
     /** @override */
     static get defaultOptions() {
-        let newOptions = super.defaultOptions;
+        const newOptions = super.defaultOptions;
         newOptions.classes = ['megs', 'sheet', 'actor'];
         newOptions.width = 650;
         newOptions.height = 600;
@@ -23,7 +23,7 @@ export class MEGSCharacterBuilderSheet extends MEGSActorSheet {
 
     /** @override */
     get template() {
-        return `systems/megs/templates/actor/character-creator-sheet.hbs`;
+        return 'systems/megs/templates/actor/character-creator-sheet.hbs';
     }
 
     /** @override */
@@ -172,12 +172,12 @@ export class MEGSCharacterBuilderSheet extends MEGSActorSheet {
                 await this.actor.update({
                     'system.wealthAdjustForInflation': false,
                     'system.wealthYear': 1990,
-                    'system.wealth': currentWealth  // Preserve wealth selection
+                    'system.wealth': currentWealth // Preserve wealth selection
                 });
             } else {
                 await this.actor.update({
                     'system.wealthAdjustForInflation': true,
-                    'system.wealth': currentWealth  // Preserve wealth selection
+                    'system.wealth': currentWealth // Preserve wealth selection
                 });
             }
             console.log('After update - wealth:', this.actor.system.wealth);
@@ -194,7 +194,7 @@ export class MEGSCharacterBuilderSheet extends MEGSActorSheet {
 
             await this.actor.update({
                 'system.wealthYear': selectedYear,
-                'system.wealth': currentWealth  // Preserve wealth selection
+                'system.wealth': currentWealth // Preserve wealth selection
             });
             console.log('After update - wealth:', this.actor.system.wealth);
         });

--- a/module/sheets/gadget-builder-sheet.mjs
+++ b/module/sheets/gadget-builder-sheet.mjs
@@ -8,7 +8,7 @@ import { MEGS } from '../helpers/config.mjs';
 export class MEGSGadgetBuilderSheet extends MEGSItemSheet {
     /** @override */
     static get defaultOptions() {
-        let newOptions = super.defaultOptions;
+        const newOptions = super.defaultOptions;
         newOptions.classes = ['megs', 'sheet', 'item', 'gadget-builder'];
         newOptions.width = 750;
         newOptions.height = 700;
@@ -24,7 +24,7 @@ export class MEGSGadgetBuilderSheet extends MEGSItemSheet {
 
     /** @override */
     get template() {
-        return `systems/megs/templates/item/gadget-builder-sheet.hbs`;
+        return 'systems/megs/templates/item/gadget-builder-sheet.hbs';
     }
 
     /** @override */
@@ -57,9 +57,9 @@ export class MEGSGadgetBuilderSheet extends MEGSItemSheet {
         }
 
         // Provide all items for helpers
-        context.items = this.object.parent ?
-            Array.from(this.object.parent.items) :
-            [...context.powers, ...context.skills, ...context.advantages, ...context.drawbacks];
+        context.items = this.object.parent
+            ? Array.from(this.object.parent.items)
+            : [...context.powers, ...context.skills, ...context.advantages, ...context.drawbacks];
 
         // Add reliability scores for settings dropdown
         context.reliabilityScores = CONFIG.reliabilityScores || [0, 2, 3, 5, 7, 9, 11];

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -457,7 +457,7 @@ export class MEGSItemSheet extends ItemSheet {
 
             if (isStandalonePowerOrSkill && (isVirtualBonus || isVirtualLimitation)) {
                 // Standalone power/skill - delete virtual modifier from flattened array
-                const index = parseInt(itemId.split('-')[2]);
+                const index = Number.parseInt(itemId.split('-')[2]);
                 const arrayKey = isVirtualBonus ? 'bonuses' : 'limitations';
                 const modifiers = foundry.utils.duplicate(this.object.system[arrayKey] || []);
 
@@ -519,8 +519,8 @@ export class MEGSItemSheet extends ItemSheet {
 
             if (this.object.type === MEGS.itemTypes.power) {
                 // for powers, AV and EV are typically APs of power
-                actionValue = parseInt(dataset.value);
-                effectValue = parseInt(dataset.value);
+                actionValue = Number.parseInt(dataset.value);
+                effectValue = Number.parseInt(dataset.value);
 
                 // TODO physical powers should have AV of DEX, mental INT, mystical INFL - optional rule
 
@@ -547,14 +547,14 @@ export class MEGSItemSheet extends ItemSheet {
                 dataset.type === MEGS.itemTypes.skill ||
                 dataset.type === MEGS.itemTypes.subskill
             ) {
-                actionValue = parseInt(dataset.value);
-                effectValue = parseInt(dataset.value);
+                actionValue = Number.parseInt(dataset.value);
+                effectValue = Number.parseInt(dataset.value);
             }
 
             // values of powers on gadget sheets
             if (dataset.type === MEGS.itemTypes.power) {
-                actionValue = parseInt(dataset.value);
-                effectValue = parseInt(dataset.value);
+                actionValue = Number.parseInt(dataset.value);
+                effectValue = Number.parseInt(dataset.value);
             }
 
             // If dataset.type is not set, use the object type (for backward compatibility)
@@ -611,7 +611,7 @@ export class MEGSItemSheet extends ItemSheet {
             let resistanceValue = 0;
 
             if (dataset.type === 'attribute') {
-                actionValue = parseInt(dataset.value);
+                actionValue = Number.parseInt(dataset.value);
                 const targetActor = MegsTableRolls.getTargetActor();
                 if (targetActor) {
                     opposingValue = Utils.getOpposingValue(dataset.key, targetActor);
@@ -621,8 +621,8 @@ export class MEGSItemSheet extends ItemSheet {
                 effectValue = Utils.getEffectValue(dataset.key, this.object);
             } else if (dataset.type === 'gadget') {
                 // For gadgets, use the actionValue and effectValue from the dataset
-                actionValue = parseInt(dataset.actionvalue);
-                effectValue = parseInt(dataset.effectvalue);
+                actionValue = Number.parseInt(dataset.actionvalue);
+                effectValue = Number.parseInt(dataset.effectvalue);
             }
 
             let label = dataset.label;

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -21,7 +21,7 @@ export class MEGSItemSheet extends ItemSheet {
 
     /** @override */
     static get defaultOptions() {
-        let newOptions = super.defaultOptions;
+        const newOptions = super.defaultOptions;
         newOptions.classes = ['megs', 'sheet', 'item'];
         newOptions.width = 667;
         newOptions.height = 480;
@@ -102,7 +102,7 @@ export class MEGSItemSheet extends ItemSheet {
             // Always display parent skill's APs
             const actor = game.actors.get(context.document.system.actorId);
             if (actor) {
-                var skill = actor.items.filter((obj) => {
+                const skill = actor.items.filter((obj) => {
                     return obj._id === context.document.system.parent;
                 })[0];
                 if (skill) {
@@ -137,8 +137,8 @@ export class MEGSItemSheet extends ItemSheet {
 
         // store all skills for dropdown on subskill page
         if (itemData.type === MEGS.itemTypes.subskill) {
-            let allSkills = {};
-            for (let i of game.items) {
+            const allSkills = {};
+            for (const i of game.items) {
                 if (i.type === MEGS.itemTypes.skill) {
                     allSkills[i.name] = i;
                 }
@@ -148,14 +148,14 @@ export class MEGSItemSheet extends ItemSheet {
 
         context.isRollable = this._isRollable(itemData);
 
-        context.hasActor = this.object.parent ? true : false;
+        context.hasActor = !!this.object.parent;
 
         // if has actor parent, store powers that actor has; otherwise, store all powers
         if (itemData.type === MEGS.itemTypes.bonus || itemData.type === MEGS.itemTypes.limitation) {
             if (context.hasActor) {
-                let powers = [];
+                const powers = [];
                 const actor = this.object.parent;
-                for (let i of actor.items) {
+                for (const i of actor.items) {
                     if (i.type === MEGS.itemTypes.power) {
                         powers.push(i);
                     }
@@ -203,7 +203,7 @@ export class MEGSItemSheet extends ItemSheet {
         // only subskills with dice or both types for parent skill + rollable are rollable
         if (itemData.type === MEGS.itemTypes.subskill) {
             const actor = game.actors.get(itemData.system.actorId);
-            var skill = actor.items.filter((obj) => {
+            const skill = actor.items.filter((obj) => {
                 return obj._id === itemData.system.parent;
             })[0];
 
@@ -242,7 +242,7 @@ export class MEGSItemSheet extends ItemSheet {
             const isEditMode = this.object.getFlag('megs', 'edit-mode') === true;
             const checkboxes = html.find('.subskills input[type="checkbox"][name^="items."]');
 
-            checkboxes.each(function() {
+            checkboxes.each(function () {
                 const checkbox = $(this);
 
                 if (skillAps === 0) {
@@ -446,7 +446,7 @@ export class MEGSItemSheet extends ItemSheet {
             const typeDisplay = typeof itemType === 'string' ? itemType.charAt(0).toUpperCase() + itemType.slice(1) : 'Item';
             const confirmed = await Dialog.confirm({
                 title: `Delete ${typeDisplay}: ${itemName}`,
-                content: `<p style="font-family: Helvetica, Arial, sans-serif;"><strong>Are You Sure?</strong> This item will be permanently deleted and cannot be recovered.</p>`,
+                content: '<p style="font-family: Helvetica, Arial, sans-serif;"><strong>Are You Sure?</strong> This item will be permanently deleted and cannot be recovered.</p>',
                 defaultYes: false,
                 options: {
                     classes: ['megs', 'dialog']
@@ -515,7 +515,7 @@ export class MEGSItemSheet extends ItemSheet {
             let opposingValue = 0;
             let resistanceValue = 0;
 
-            let targetActor = MegsTableRolls.getTargetActor();
+            const targetActor = MegsTableRolls.getTargetActor();
 
             if (this.object.type === MEGS.itemTypes.power) {
                 // for powers, AV and EV are typically APs of power
@@ -612,7 +612,7 @@ export class MEGSItemSheet extends ItemSheet {
 
             if (dataset.type === 'attribute') {
                 actionValue = parseInt(dataset.value);
-                let targetActor = MegsTableRolls.getTargetActor();
+                const targetActor = MegsTableRolls.getTargetActor();
                 if (targetActor) {
                     opposingValue = Utils.getOpposingValue(dataset.key, targetActor);
                     resistanceValue = Utils.getResistanceValue(dataset.key, targetActor);
@@ -660,7 +660,7 @@ export class MEGSItemSheet extends ItemSheet {
         });
 
         if (this.object.parent && this.object.parent.isOwner) {
-            let handler = (ev) => this._onDragStart(ev);
+            const handler = (ev) => this._onDragStart(ev);
             html.find('li.item').each((i, li) => {
                 if (li.classList.contains('inventory-header')) return;
                 li.setAttribute('draggable', true);
@@ -690,7 +690,7 @@ export class MEGSItemSheet extends ItemSheet {
         // For items on actors/gadgets, read from embedded items collection
         if (this.object.parent && this.object.parent.items) {
             // Iterate through items, allocating to containers
-            for (let i of this.object.parent.items) {
+            for (const i of this.object.parent.items) {
                 // if modifier belongs to this power/skill
                 if (i.system.parent === this.item._id) {
                     i.img = i.img || Item.DEFAULT_ICON;
@@ -762,7 +762,7 @@ export class MEGSItemSheet extends ItemSheet {
             let subskills = [];
 
             if (this.object.parent) {
-                for (let i of this.object.parent.items) {
+                for (const i of this.object.parent.items) {
                     if (i.type === MEGS.itemTypes.subskill) {
                         if (i.system.parent === context.item._id) {
                             // Subskills inherit APs from parent skill
@@ -832,7 +832,7 @@ export class MEGSItemSheet extends ItemSheet {
         const subskillData = context.system.subskillData || {};
 
         // Create virtual skill items
-        for (let [skillName, aps] of Object.entries(skillData)) {
+        for (const [skillName, aps] of Object.entries(skillData)) {
             // Look up the correct icon for this skill from CONFIG.skills
             let skillImg = 'systems/megs/assets/images/icons/skillls/skill.png'; // default
             if (CONFIG.skills) {
@@ -859,7 +859,7 @@ export class MEGSItemSheet extends ItemSheet {
         }
 
         // Create virtual subskill items
-        for (let [subskillName, aps] of Object.entries(subskillData)) {
+        for (const [subskillName, aps] of Object.entries(subskillData)) {
             const virtualSubskill = {
                 _id: `virtual-subskill-${subskillName}`,
                 name: subskillName,
@@ -867,7 +867,7 @@ export class MEGSItemSheet extends ItemSheet {
                 img: 'systems/megs/assets/images/icons/skillls/skill.png',
                 system: {
                     aps: aps,
-                    parent: `virtual-skill-parent`,
+                    parent: 'virtual-skill-parent',
                     linkedSkill: '',
                     useUnskilled: 'false'
                 },
@@ -889,7 +889,7 @@ export class MEGSItemSheet extends ItemSheet {
         const traitData = context.system.traitData || {};
 
         // Create virtual trait items (advantages and drawbacks)
-        for (let [key, trait] of Object.entries(traitData)) {
+        for (const [key, trait] of Object.entries(traitData)) {
             const virtualTrait = {
                 _id: `virtual-trait-${key}`,
                 name: trait.name,
@@ -920,7 +920,7 @@ export class MEGSItemSheet extends ItemSheet {
         const powerLinks = context.system.powerLinks || {};
 
         // Create virtual power items from flattened data
-        for (let powerName of Object.keys(powerAPs)) {
+        for (const powerName of Object.keys(powerAPs)) {
             const virtualPower = {
                 _id: `virtual-power-${powerName}`,
                 name: powerName,
@@ -948,7 +948,7 @@ export class MEGSItemSheet extends ItemSheet {
      */
     _prepareGadgetData(context) {
         // Handle attribute scores.
-        for (let [k, v] of Object.entries(context.system.attributes)) {
+        for (const [k, v] of Object.entries(context.system.attributes)) {
             v.label = game.i18n.localize(CONFIG.MEGS.attributes[k]) ?? k;
         }
 
@@ -964,7 +964,7 @@ export class MEGSItemSheet extends ItemSheet {
         const gadgets = [];
 
         let items = [];
-        let isStandalone = !context.document.parent;
+        const isStandalone = !context.document.parent;
 
         if (context.document.parent) {
             // Gadget owned by actor - get actual items from the actor
@@ -984,37 +984,28 @@ export class MEGSItemSheet extends ItemSheet {
         }
 
         // First pass: collect items that belong to this gadget
-        for (let i of items) {
+        for (const i of items) {
             if (isStandalone || i.system.parent === this.document._id) {
                 i.img = i.img || Item.DEFAULT_ICON;
 
                 // Append to powers
                 if (i.type === MEGS.itemTypes.power) {
                     powers.push(i);
-                }
-                // Append to skills
-                else if (i.type === MEGS.itemTypes.skill) {
+                } else if (i.type === MEGS.itemTypes.skill) {
                     i.subskills = [];
                     if (i.system.aps === 0) {
                         i.unskilled = true;
-                        // Safely access linked attribute value
                         const linkedAttr = i.system.link && this.object.system.attributes?.[i.system.link];
                         i.linkedAPs = linkedAttr?.value ?? 0;
                     } else {
                         i.unskilled = false;
                     }
                     skills.push(i);
-                }
-                // Append to advantages
-                else if (i.type === MEGS.itemTypes.advantage) {
+                } else if (i.type === MEGS.itemTypes.advantage) {
                     advantages.push(i);
-                }
-                // Append to drawbacks
-                else if (i.type === MEGS.itemTypes.drawback) {
+                } else if (i.type === MEGS.itemTypes.drawback) {
                     drawbacks.push(i);
-                }
-                // Append to gadgets
-                else if (i.type === MEGS.itemTypes.gadget) {
+                } else if (i.type === MEGS.itemTypes.gadget) {
                     gadgets.push(i);
                 }
             }
@@ -1022,7 +1013,7 @@ export class MEGSItemSheet extends ItemSheet {
 
         // Second pass: collect subskills whose parent is one of the gadget's skills
         const skillIds = skills.map(s => s._id);
-        for (let i of items) {
+        for (const i of items) {
             if (i.type === MEGS.itemTypes.subskill && skillIds.includes(i.system.parent)) {
                 i.skill = context.item;
                 subskills.push(i);
@@ -1033,8 +1024,8 @@ export class MEGSItemSheet extends ItemSheet {
         const arrays = [powers, skills, advantages, drawbacks, subskills, gadgets];
         arrays.forEach((element) => {
             element.sort(function (a, b) {
-                let textA = a.name.toUpperCase();
-                let textB = b.name.toUpperCase();
+                const textA = a.name.toUpperCase();
+                const textB = b.name.toUpperCase();
                 return textA < textB ? -1 : textA > textB ? 1 : 0;
             });
         });
@@ -1089,7 +1080,7 @@ export class MEGSItemSheet extends ItemSheet {
         };
 
         // Remove the type from the dataset since it's in the itemData.type prop.
-        delete itemData.system['type'];
+        delete itemData.system.type;
 
         // Handle standalone gadgets creating traits
         if (!this.object.parent && this.object.type === MEGS.itemTypes.gadget &&
@@ -1213,10 +1204,10 @@ export class MEGSItemSheet extends ItemSheet {
         // Handle different data types
         // TODO remove this?
         switch (data.type) {
-            // case "ActiveEffect":
-            //   return this._onDropActiveEffect(event, data);
-            case 'Item':
-                return this._onDropItem(event, data);
+        // case "ActiveEffect":
+        //   return this._onDropActiveEffect(event, data);
+        case 'Item':
+            return this._onDropItem(event, data);
         }
     }
 
@@ -1417,7 +1408,7 @@ export class MEGSItemSheet extends ItemSheet {
 
         // Identify sibling items based on adjacent HTML elements
         const siblings = [];
-        for (let el of dropTarget.parentElement.children) {
+        for (const el of dropTarget.parentElement.children) {
             const siblingId = el.dataset.itemId;
             if (siblingId && siblingId !== source.id) siblings.push(items.get(el.dataset.itemId));
         }
@@ -1472,11 +1463,7 @@ export class MEGSItemSheet extends ItemSheet {
     _openSettings(e) {
         e.preventDefault();
         // Find and activate the settings tab
-        const tabs = this.element.find('.tabs[data-group="primary"]');
-        const settingsTab = tabs.find('a[data-tab="settings"]');
-
-        // If the tab link doesn't exist in nav (which it doesn't), we need to manually activate
-        // Find the tab content and activate it
+        // Manually activate the settings tab content
         this.element.find('.tab[data-tab="settings"]').addClass('active');
         this.element.find('.tab').not('[data-tab="settings"]').removeClass('active');
     }

--- a/src/scss/components/_chat.scss
+++ b/src/scss/components/_chat.scss
@@ -63,7 +63,7 @@ li.chat-message {
 
         .d10 {
             display: inline-block;
-            background-image: url(/icons/svg/d10-grey.svg);
+            background-image: url("/icons/svg/d10-grey.svg");
             min-width: 24px;
             line-height: 24px;
             margin-right: 1px;

--- a/src/scss/components/_dialogs.scss
+++ b/src/scss/components/_dialogs.scss
@@ -45,7 +45,7 @@
             }
 
             &:active {
-                background-color: darken($c-darkblue, 10%);
+                background-color: darken($c-darkblue, 10%); /* stylelint-disable-line scss/no-global-function-names */
             }
         }
     }

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -71,11 +71,11 @@
             margin-top: 5px;
 
             &.isLocked {
-                background-image: url(/systems/megs/assets/images/icons/locked.png);
+                background-image: url("/systems/megs/assets/images/icons/locked.png");
             }
 
             &.isUnlocked {
-                background-image: url(/systems/megs/assets/images/icons/unlocked.png);
+                background-image: url("/systems/megs/assets/images/icons/unlocked.png");
             }
         }
     }
@@ -93,7 +93,7 @@
         vertical-align: bottom;
         border: none;
         cursor: pointer;
-        background-image: url(/systems/megs/assets/images/icons/reset.png);
+        background-image: url("/systems/megs/assets/images/icons/reset.png");
         background-size: 30px auto;
         background-color: $c-white;
     }
@@ -127,7 +127,7 @@
     // D10 roll button styles
     .header-fields .grid .d10 {
         display: inline-block;
-        background-image: url(/systems/megs/assets/images/icons/2d10-blue.png);
+        background-image: url("/systems/megs/assets/images/icons/2d10-blue.png");
         margin-right: 1px;
         background-repeat: no-repeat;
         background-size: 45px 45px;
@@ -148,15 +148,15 @@
         transition: 0.2s background linear;
 
         &.unskilled {
-            background-image: url(/systems/megs/assets/images/icons/2d10-blue-2.png);
+            background-image: url("/systems/megs/assets/images/icons/2d10-blue-2.png");
 
             &:hover {
-                background-image: url(/systems/megs/assets/images/icons/2d10-white-2.png);
+                background-image: url("/systems/megs/assets/images/icons/2d10-white-2.png");
             }
         }
 
         &:hover {
-            background-image: url(/systems/megs/assets/images/icons/2d10-white.png);
+            background-image: url("/systems/megs/assets/images/icons/2d10-white.png");
             background-color: $c-darkblue;
             background-size: 50px 50px;
             transition: 0.2s background linear;

--- a/src/scss/components/_items.scss
+++ b/src/scss/components/_items.scss
@@ -250,7 +250,7 @@ li.directory-item img[src*='assets/images/icons'] {
 
     .power-row.drop-target {
         background-color: #d4edff;
-        border: 2px dashed #0066cc;
+        border: 2px dashed #06c;
         box-shadow: inset 0 0 8px rgba(0, 102, 204, 0.3);
     }
 

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/218-clean-up-lint-findings/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/218-clean-up-lint-findings/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/218-clean-up-lint-findings",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary
- Resolves all 239 ESLint findings and 10 Stylelint findings across 16 files
- **Auto-fixed (215):** `prefer-const`, `quotes`, `indent`, `no-multi-spaces`, `brace-style`, `dot-notation`, `curly`, `no-unneeded-ternary`, `no-var`, `no-multiple-empty-lines`, `function-url-quotes`, `color-hex-length`
- **Manually fixed (22):** unused imports/variables (`no-unused-vars`), useless constructor (`no-useless-constructor`), useless returns (`no-useless-return`), brace-style in `else if` chains, unused `resultTable` variable in dice.mjs
- **Suppressed (1):** `darken()` in `_dialogs.scss` — requires `@import` → `@use` migration to properly fix
- Replaced 37 global `parseInt()` calls with `Number.parseInt()` across 6 modules (SonarCloud code smell)
- Added CHANGELOG 1.0.1 section covering all changes since 1.0.0
- `npm run lint` now exits cleanly with zero findings
- All 72 unit tests pass

Fixes #218