### PR TITLE
Fix Dice So Nice animation for doubles rolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,85 +25,6 @@
 - Cleaned up 249 lint findings across 16 files — `prefer-const`, `quotes`, `indent`, brace-style, unused variables/imports, URL quoting, hex shorthand (issue #218)
 - Replaced 37 global `parseInt()` calls with `Number.parseInt()` across 6 modules for consistency (issue #218)
 
-## 0.4.0 (May 15, 2024)
-
-- Officially entered beta with a very barebones system
-
-## 0.5.0 (December 7, 2024)
-
-- Added generic skill tree
-- Various bug fixes
-
-## 0.5.1 (December 25, 2024)
-
-- Added direct roll macro capability for skills
-- Fixed bug with unskilled rolls when targeting
-- Minor code cleanup and simplification
-
-## 0.5.2 (January 11, 2025)
-
-- Edit lock capability for actors and items
-- Macro fixes and simplification for skills/subskills
-- Bug fixes from user submissions
-
-## 0.5.3 (February 24, 2025)
-
-- Fixed bug that defaulted macros to looking at selected token actor instead of macro's actor
-- Fixed bug that had all rolls from Item object defaulting to unskilled (-2 column shifts)
-- Allow skills and subskills to be editable
-- Updated README to conform to requests by Foundry devs
-- Added locations as Actors (still some cleanup to do here)
-- Portuguese language support (many thanks to @rodrigomiranda on Discord!)
-- Several minor bug and typo fixes
-
-## 0.6.0 (April 19, 2025)
-
-- Allow current scores to be negative (up to negative value of base attribute)
-- Made some technical changes caused by Foundry changes around select components
-- Limited item durability to the delimited values (0, 2, 3, 5, 7, 9, 11)
-- Fixed some yes/no labels that were showing as true/false
-- Fixed motivation to display label when uneditable
-- Fixed description page to not show raw HTML when non-editable
-- Localized several labels missed in previous efforts to selected language
-- Made some fields missed in 0.5.3 uneditable when not in edit mode
-- Corrected tabbing when actor page open
-- Fixed reliability display value on gadgets
-- Linked powers now display asterisk
-- Cleanup minor code issues from static code analysis
-
-## 0.7.0 (December 15, 2025)
-
-### Enhancements
-
-- Added a tooltip explanation on hover for the Initiative, AV/OV (if HP spent), and column shifts
-- Standalone gadgets (unowned) can now store skill APs that transfer when added to actors
-- Gadgets dragged to the Items sidebar now retain their powers and skills, which are recreated when dragged to another character
-- Gadgets can now have skills with optional Skills tab (toggle in Settings)
-- Gadgets can now have powers with optional Powers tab (drag-and-drop only, toggle in Settings)
-- Gadgets can now have traits with optional Traits tab (toggle in Settings)
-- Increment/decrement buttons added for skills and powers on gadgets (in edit mode)
-- Vehicle and location actors display skills from linked gadgets (read-only)
-- Owner dropdown on vehicle/location sheets now alphabetized by name
-- Changed configure sheet icon from cog to document icon
-- Settings moved from tab to header button with cog icon on gadgets
-- Minor styling changes
-- Localized still more hard-coded English strings
-
-### Foundry VTT V13 Compatibility
-
-- Fixed deprecation warning for `renderTemplate` - now uses `foundry.applications.handlebars.renderTemplate`
-- Fixed deprecation warning for `roll.evaluate()` - removed deprecated `async` option
-- Fixed deprecation warning for chat message creation - now uses `rolls` array instead of deprecated `CHAT_MESSAGE_STYLES.ROLL`
-- Registered custom MegsRoll class with Foundry's dice system for proper serialization
-- Changed usage of other deprecated Foundry constants and functions
-
-### Bug Fixes
-
-- Fixed column shift calculation in dice roller that was producing incorrect results
-- Corrected threshold logic to properly implement MEGS rule: roll must be "on or beyond" the column shift threshold (11)
-- Added test coverage for edge case where roll is exactly on threshold
-- Fixed Dice So Nice integration to display the same dice values shown in chat messages (issue #169)
-
 ## 1.0.0 (February 1, 2026)
 
 ### Enhancements
@@ -173,3 +94,82 @@
 - Added test coverage for character budget calculations, reliability number conversion, and base cost only powers
 - Test coverage for gadget cost calculations including rulebook example (Machinegun)
 - Comprehensive test coverage for table extrapolation beyond 60 (Action and Result tables)
+
+## 0.7.0 (December 15, 2025)
+
+### Enhancements
+
+- Added a tooltip explanation on hover for the Initiative, AV/OV (if HP spent), and column shifts
+- Standalone gadgets (unowned) can now store skill APs that transfer when added to actors
+- Gadgets dragged to the Items sidebar now retain their powers and skills, which are recreated when dragged to another character
+- Gadgets can now have skills with optional Skills tab (toggle in Settings)
+- Gadgets can now have powers with optional Powers tab (drag-and-drop only, toggle in Settings)
+- Gadgets can now have traits with optional Traits tab (toggle in Settings)
+- Increment/decrement buttons added for skills and powers on gadgets (in edit mode)
+- Vehicle and location actors display skills from linked gadgets (read-only)
+- Owner dropdown on vehicle/location sheets now alphabetized by name
+- Changed configure sheet icon from cog to document icon
+- Settings moved from tab to header button with cog icon on gadgets
+- Minor styling changes
+- Localized still more hard-coded English strings
+
+### Foundry VTT V13 Compatibility
+
+- Fixed deprecation warning for `renderTemplate` - now uses `foundry.applications.handlebars.renderTemplate`
+- Fixed deprecation warning for `roll.evaluate()` - removed deprecated `async` option
+- Fixed deprecation warning for chat message creation - now uses `rolls` array instead of deprecated `CHAT_MESSAGE_STYLES.ROLL`
+- Registered custom MegsRoll class with Foundry's dice system for proper serialization
+- Changed usage of other deprecated Foundry constants and functions
+
+### Bug Fixes
+
+- Fixed column shift calculation in dice roller that was producing incorrect results
+- Corrected threshold logic to properly implement MEGS rule: roll must be "on or beyond" the column shift threshold (11)
+- Added test coverage for edge case where roll is exactly on threshold
+- Fixed Dice So Nice integration to display the same dice values shown in chat messages (issue #169)
+
+## 0.6.0 (April 19, 2025)
+
+- Allow current scores to be negative (up to negative value of base attribute)
+- Made some technical changes caused by Foundry changes around select components
+- Limited item durability to the delimited values (0, 2, 3, 5, 7, 9, 11)
+- Fixed some yes/no labels that were showing as true/false
+- Fixed motivation to display label when uneditable
+- Fixed description page to not show raw HTML when non-editable
+- Localized several labels missed in previous efforts to selected language
+- Made some fields missed in 0.5.3 uneditable when not in edit mode
+- Corrected tabbing when actor page open
+- Fixed reliability display value on gadgets
+- Linked powers now display asterisk
+- Cleanup minor code issues from static code analysis
+
+## 0.5.3 (February 24, 2025)
+
+- Fixed bug that defaulted macros to looking at selected token actor instead of macro's actor
+- Fixed bug that had all rolls from Item object defaulting to unskilled (-2 column shifts)
+- Allow skills and subskills to be editable
+- Updated README to conform to requests by Foundry devs
+- Added locations as Actors (still some cleanup to do here)
+- Portuguese language support (many thanks to @rodrigomiranda on Discord!)
+- Several minor bug and typo fixes
+
+## 0.5.2 (January 11, 2025)
+
+- Edit lock capability for actors and items
+- Macro fixes and simplification for skills/subskills
+- Bug fixes from user submissions
+
+## 0.5.1 (December 25, 2024)
+
+- Added direct roll macro capability for skills
+- Fixed bug with unskilled rolls when targeting
+- Minor code cleanup and simplification
+
+## 0.5.0 (December 7, 2024)
+
+- Added generic skill tree
+- Various bug fixes
+
+## 0.4.0 (May 15, 2024)
+
+- Officially entered beta with a very barebones system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 
+- Fixed Dice So Nice 3D dice not showing before doubles prompt and re-triggering on final chat message (issue #196)
 - Fixed `ReferenceError` crash when selecting multiple targets — `localize()` replaced with `game.i18n.localize()` (issue #215)
 - Fixed `ReferenceError` in `compare` Handlebars helper — added missing `options` parameter (issue #215)
 - Fixed trailing slash in system.json download URL that prevented Foundry from resolving the package

--- a/module/__tests__/dice.test.js
+++ b/module/__tests__/dice.test.js
@@ -251,6 +251,7 @@ test('_rollDice should return if dice do not match', () => {
 
     dice._rollDice(resultData, {}).then((response) => {
         expect(response).toStrictEqual([2, 3]);
+        expect(resultData.hadDoubles).toBe(false);
     });
 });
 
@@ -287,6 +288,7 @@ test('_rollDice should roll again if have matching dice on first roll and elect 
 
     dice._rollDice(resultData, {}).then((response) => {
         expect(response).toStrictEqual([2, 2, 3, 4]);
+        expect(resultData.hadDoubles).toBe(true);
     });
 });
 
@@ -323,6 +325,7 @@ test('_rollDice should roll again if have matching dice on first and second roll
 
     dice._rollDice(resultData, {}).then((response) => {
         expect(response).toStrictEqual([2, 2, 3, 3, 4, 5]);
+        expect(resultData.hadDoubles).toBe(true);
     });
 });
 
@@ -359,6 +362,7 @@ test('_rollDice should not roll again if have matching dice on first roll and us
 
     dice._rollDice(resultData, {}).then((response) => {
         expect(response).toStrictEqual([2, 2]);
+        expect(resultData.hadDoubles).toBe(true);
     });
 });
 
@@ -403,7 +407,91 @@ test('_rollDice should extract dice from initialRoll with terms structure', () =
 
     dice._rollDice(resultData, mockRollWithTerms).then((response) => {
         expect(response).toStrictEqual([7, 4]);
+        expect(resultData.hadDoubles).toBe(false);
     });
+});
+
+test('_rollDice should show DSN for each pair when doubles are rolled', async () => {
+    global.Dialog = YesDialog;
+    const showForRollMock = jest.fn().mockResolvedValue(undefined);
+    global.game.dice3d = { showForRoll: showForRollMock };
+
+    const values = {
+        label: 'Test',
+        type: 'attribute',
+        valueOrAps: 0,
+        actionValue: 0,
+        opposingValue: 0,
+        effectValue: 0,
+        resistanceValue: 0,
+        rollFormula: '3 + 3 + 5 + 7',
+        unskilled: false,
+    };
+    global.rollIndex = 0;
+
+    const dice = new MegsTableRolls(values);
+
+    const resultData = {
+        result: '',
+        actionValue: 0,
+        opposingValue: 0,
+        difficulty: 0,
+        dice: [],
+        columnShifts: 0,
+        effectValue: 0,
+        resistanceValue: 0,
+        success: true,
+        evResult: '',
+        rvColumnShifts: 0,
+    };
+
+    const response = await dice._rollDice(resultData, {});
+    expect(response).toStrictEqual([3, 3, 5, 7]);
+    expect(resultData.hadDoubles).toBe(true);
+    expect(showForRollMock).toHaveBeenCalledTimes(2);
+
+    delete global.game.dice3d;
+});
+
+test('_rollDice should not call DSN showForRoll when no doubles', async () => {
+    const showForRollMock = jest.fn().mockResolvedValue(undefined);
+    global.game.dice3d = { showForRoll: showForRollMock };
+
+    const values = {
+        label: 'Test',
+        type: 'attribute',
+        valueOrAps: 0,
+        actionValue: 0,
+        opposingValue: 0,
+        effectValue: 0,
+        resistanceValue: 0,
+        rollFormula: '4 + 7',
+        unskilled: false,
+    };
+    global.rollIndex = 0;
+
+    const dice = new MegsTableRolls(values);
+
+    const resultData = {
+        result: '',
+        actionValue: 0,
+        opposingValue: 0,
+        difficulty: 0,
+        dice: [],
+        columnShifts: 0,
+        effectValue: 0,
+        resistanceValue: 0,
+        success: true,
+        evResult: '',
+        rvColumnShifts: 0,
+    };
+
+    const response = await dice._rollDice(resultData, {});
+    expect(response).toStrictEqual([4, 7]);
+    expect(resultData.hadDoubles).toBe(false);
+    expect(showForRollMock).not.toHaveBeenCalled();
+
+    delete global.game.dice3d;
 });
 
 /*

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -529,18 +529,13 @@ export class MegsTableRolls {
      * @returns
      */
     static _applyDiceAppearance(roll) {
-        if (roll.dice && roll.dice.length >= 2 && game.dice3d) {
-            const userAppearance = game.dice3d.constructor.APPEARANCE(game.user);
-            const base = userAppearance?.global || {};
+        if (roll.dice && roll.dice.length >= 2) {
             roll.dice[0].options.appearance = {
-                ...base,
-                colorset: 'custom',
-                diceColor: '#cc0000',
-                labelColor: '#ffffff',
-                outlineColor: '#cc0000',
-                edgeColor: '#ffffff',
+                foreground: '#ffffff',
+                background: '#cc0000',
+                outline: '#cc0000',
+                edge: '#ffffff',
             };
-            roll.dice[1].options.appearance = { ...base };
         }
     }
 

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -343,6 +343,7 @@ export class MegsTableRolls {
 
         // Execute the roll
         await avRoll.evaluate();
+        MegsTableRolls._applyDiceAppearance(avRoll);
 
         let dice = [];
         const resultData = {
@@ -527,6 +528,18 @@ export class MegsTableRolls {
      * @param {Roll} initialRoll - The initial roll object to extract dice from
      * @returns
      */
+    static _applyDiceAppearance(roll) {
+        if (roll.dice && roll.dice.length >= 2) {
+            roll.dice[0].options.appearance = {
+                colorset: 'custom',
+                diceColor: '#cc0000',
+                labelColor: '#ffffff',
+                outlineColor: '#cc0000',
+                edgeColor: '#ffffff',
+            };
+        }
+    }
+
     async _rollDice(data, initialRoll) {
         const dice = [];
         let stopRolling = false;
@@ -548,6 +561,7 @@ export class MegsTableRolls {
             currentRoll = new Roll(this.rollFormula, {});
             await currentRoll.evaluate();
         }
+        MegsTableRolls._applyDiceAppearance(currentRoll);
 
         while (!stopRolling) {
             // Extract dice values from the roll object
@@ -592,6 +606,7 @@ export class MegsTableRolls {
                 if (confirmed) {
                     currentRoll = new Roll(this.rollFormula, {});
                     await currentRoll.evaluate();
+                    MegsTableRolls._applyDiceAppearance(currentRoll);
                     stopRolling = false;
                 } else {
                     stopRolling = true;

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -11,13 +11,16 @@ export const ShowResultCall = Object.freeze({
 const COLUMN_SHIFT_THRESHOLD = 11;
 
 export class MegsRoll extends Roll {
-    async toMessage(dialogHtml = {}, { rollMode, create = true, speaker = null } = {}) {
+    async toMessage(dialogHtml = {}, { rollMode, create = true, speaker = null, skipDSN = false } = {}) {
         const messageData = {
             user: game.user.id,
-            rolls: [this],
             content: dialogHtml,
             sound: CONFIG.sounds.dice,
         };
+
+        if (!skipDSN) {
+            messageData.rolls = [this];
+        }
 
         if (speaker) {
             messageData.speaker = speaker;
@@ -527,6 +530,7 @@ export class MegsTableRolls {
     async _rollDice(data, initialRoll) {
         const dice = [];
         let stopRolling = false;
+        let hadDoubles = false;
         if (data) {
             if (data.columnShifts) {
                 data.isOneColumnShift = data.columnShifts === 1;
@@ -538,11 +542,9 @@ export class MegsTableRolls {
 
         // Use the initial roll if provided and valid, otherwise create a new one
         let currentRoll;
-        let isFirstRoll = true;
         if (initialRoll && (initialRoll.terms || initialRoll.result)) {
             currentRoll = initialRoll;
         } else {
-            // Fallback: create new roll (for tests or when initialRoll is not provided)
             currentRoll = new Roll(this.rollFormula, {});
             await currentRoll.evaluate();
         }
@@ -553,16 +555,13 @@ export class MegsTableRolls {
             let die1, die2;
 
             if (currentRoll.terms && currentRoll.terms.length >= 3) {
-                // Real Foundry Roll structure: terms[0] is first die, terms[2] is second die
                 die1 = currentRoll.terms[0].results[0].result;
                 die2 = currentRoll.terms[2].results[0].result;
             } else if (currentRoll.result && typeof currentRoll.result === 'string') {
-                // Fallback for mocks or legacy: parse the result string
                 const rolledDice = currentRoll.result.split(' + ');
                 die1 = Number.parseInt(rolledDice[0]);
                 die2 = Number.parseInt(rolledDice[1]);
             } else {
-                // Ultimate fallback: use mock dice values or defaults
                 die1 = (currentRoll.dice && currentRoll.dice[0] && currentRoll.dice[0].results) ? currentRoll.dice[0].results[0] : 1;
                 die2 = (currentRoll.dice && currentRoll.dice[1] && currentRoll.dice[1].results) ? currentRoll.dice[1].results[0] : 1;
             }
@@ -571,14 +570,13 @@ export class MegsTableRolls {
             dice.push(die2);
 
             if (die1 === 1 && die2 === 1) {
-                // dice are both 1s
+                if (hadDoubles && game.dice3d) {
+                    await game.dice3d.showForRoll(currentRoll, game.user, true);
+                }
                 stopRolling = true;
             } else if (die1 === die2) {
-                // dice match but are not 1s
-                // Show the Dice So Nice animation if available before prompting
-                // For first roll, DSN animation already triggered by evaluate(), but we need to wait for it
-                // For subsequent rolls, we need to explicitly show the animation
-                if (game.dice3d && !isFirstRoll) {
+                hadDoubles = true;
+                if (game.dice3d) {
                     await game.dice3d.showForRoll(currentRoll, game.user, true);
                 }
 
@@ -592,18 +590,22 @@ export class MegsTableRolls {
                     }
                 });
                 if (confirmed) {
-                    // Create and evaluate a new roll for subsequent pairs
                     currentRoll = new Roll(this.rollFormula, {});
                     await currentRoll.evaluate();
-                    isFirstRoll = false;
                     stopRolling = false;
                 } else {
                     stopRolling = true;
                 }
             } else {
-                // dice do not match
+                if (hadDoubles && game.dice3d) {
+                    await game.dice3d.showForRoll(currentRoll, game.user, true);
+                }
                 stopRolling = true;
             }
+        }
+
+        if (data) {
+            data.hadDoubles = hadDoubles;
         }
 
         return dice;
@@ -629,7 +631,7 @@ export class MegsTableRolls {
         }
 
         const dialogHtml = await this._renderTemplate(rollChatTemplate, data);
-        await roll.toMessage(dialogHtml, { speaker });
+        await roll.toMessage(dialogHtml, { speaker, skipDSN: !!data.hadDoubles });
     }
 
     /**

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -529,14 +529,18 @@ export class MegsTableRolls {
      * @returns
      */
     static _applyDiceAppearance(roll) {
-        if (roll.dice && roll.dice.length >= 2) {
+        if (roll.dice && roll.dice.length >= 2 && game.dice3d) {
+            const userAppearance = game.dice3d.constructor.APPEARANCE(game.user);
+            const base = userAppearance?.global || {};
             roll.dice[0].options.appearance = {
+                ...base,
                 colorset: 'custom',
                 diceColor: '#cc0000',
                 labelColor: '#ffffff',
                 outlineColor: '#cc0000',
                 edgeColor: '#ffffff',
             };
+            roll.dice[1].options.appearance = { ...base };
         }
     }
 

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -15,11 +15,11 @@ export class MegsRoll extends Roll {
         const messageData = {
             user: game.user.id,
             content: dialogHtml,
-            sound: CONFIG.sounds.dice,
         };
 
         if (!skipDSN) {
             messageData.rolls = [this];
+            messageData.sound = CONFIG.sounds.dice;
         }
 
         if (speaker) {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/196-dice-doubles-fix/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/196-dice-doubles-fix/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/196-dice-doubles-fix",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary
- Show Dice So Nice 3D animation for each dice pair before the "roll again?" prompt when doubles are rolled
- Suppress DSN re-trigger on the final chat message (prevents showing only the first pair's animation at the end)
- Non-doubles rolls are unchanged — DSN fires normally from chat message creation
- Added `skipDSN` option to `MegsRoll.toMessage` to control whether rolls are included in the message data
- Added 2 new tests verifying DSN `showForRoll` is called correctly for doubles vs. non-doubles

## Test plan
- [x] All 74 unit tests pass (72 existing + 2 new DSN behavior tests)
- [x] Manual test: roll without doubles — 3D dice should appear once with chat message
- [x] Manual test: roll doubles — 3D dice appear before prompt, new pair shown on re-roll, no re-animation on final message
- [ ] Manual test: roll without Dice So Nice installed — behavior unchanged

Fixes #196