### PR TITLE
Add detail field to advantage and drawback traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Added editable detail/subtext field on advantage and drawback item sheets, displayed in parentheses on actor traits tab and character creator (issue #209)
 - Alphabetized advantages and drawbacks on character builder sheet
 - Added post-merge hook to sync README version references automatically
 - Added post-checkout hook to auto-update system.json branch URLs on branch switch

--- a/lang/en.json
+++ b/lang/en.json
@@ -63,6 +63,7 @@
         "Cost": "Cost",
         "Current": "Current",
         "Description": "Description",
+        "Detail": "Detail",
         "Difficulty": "Difficulty",
         "Double1s": "Double 1s: Automatic failure!",
         "Drawbacks": "Drawbacks",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -63,6 +63,7 @@
         "Cost": "Custo",
         "Current": "Atual",
         "Description": "Descrição",
+        "Detail": "Detalhe",
         "Difficulty": "Dificuldade",
         "Double1s": "Duplo 1s: Falha automática!",
         "Drawbacks": "Desvantagens",

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/209-trait-subtext/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/209-trait-subtext/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/209-trait-subtext",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,

--- a/templates/actor/character-creator-sheet.hbs
+++ b/templates/actor/character-creator-sheet.hbs
@@ -343,7 +343,7 @@
                         {{#each advantages as |item id|}}
                             <li class='item flexrow item-row' data-item-id='{{item._id}}'>
                                 <div class='item-name'>
-                                    {{item.name}}
+                                    {{item.name}}{{#if item.system.text}} ({{item.system.text}}){{/if}}
                                 </div>
                                 <div class='item-cost'>
                                     {{item.system.totalCost}}
@@ -373,7 +373,7 @@
                         {{#each drawbacks as |item id|}}
                             <li class='item flexrow item-row' data-item-id='{{item._id}}'>
                                 <div class='item-name'>
-                                    {{item.name}}
+                                    {{item.name}}{{#if item.system.text}} ({{item.system.text}}){{/if}}
                                 </div>
                                 <div class='item-cost'>
                                     {{item.system.totalCost}}

--- a/templates/actor/parts/actor-traits.hbs
+++ b/templates/actor/parts/actor-traits.hbs
@@ -23,7 +23,7 @@
                             </a>
                         </div>
                         <a class='item-control item-edit bold' title='{{localize "DOCUMENT.Update" type=' Advantage'}}'>
-                            {{item.name}}
+                            {{item.name}}{{#if item.system.text}} ({{item.system.text}}){{/if}}
                         </a>
                     </div>
                     <div class='item-controls'>
@@ -64,7 +64,7 @@
                             </a>
                         </div>
                         <a class='item-control item-edit bold' title='{{localize "DOCUMENT.Update" type=' Drawback'}}'>
-                            {{item.name}}
+                            {{item.name}}{{#if item.system.text}} ({{item.system.text}}){{/if}}
                         </a>
                     </div>
                     <div class='item-controls'>

--- a/templates/item/item-advantage-sheet.hbs
+++ b/templates/item/item-advantage-sheet.hbs
@@ -10,6 +10,19 @@
             {{!-- Item name --}}
             {{> "systems/megs/templates/item/parts/item-header-name.hbs"}}
 
+            {{#if system.hasSubtext}}
+                <div class="resource flex-group-center">
+                    <label for="system.text" class="resource-label">{{localize 'MEGS.Detail'}}</label>
+                    <div class="resource-content flexrow flex-center flex-between">
+                        {{#if flags.megs.edit-mode}}
+                            <input type="text" name="system.text" value="{{system.text}}" />
+                        {{else}}
+                            <span>{{system.text}}</span>
+                        {{/if}}
+                    </div>
+                </div>
+            {{/if}}
+
             <div class="resources grid grid-2col">
 
                 <div class="resource flex-group-center">

--- a/templates/item/item-drawback-sheet.hbs
+++ b/templates/item/item-drawback-sheet.hbs
@@ -10,6 +10,15 @@
             {{!-- Item name --}}
             {{> "systems/megs/templates/item/parts/item-header-name.hbs"}}
 
+            {{#if system.hasSubtext}}
+                <div class="resource flex-group-center">
+                    <label for="system.text" class="resource-label">{{localize 'MEGS.Detail'}}</label>
+                    <div class="resource-content flexrow flex-center flex-between">
+                        <input type="text" name="system.text" value="{{system.text}}" />
+                    </div>
+                </div>
+            {{/if}}
+
             <div class="resources grid grid-2col">
 
                 <div class="resource flex-group-center">


### PR DESCRIPTION
## Summary

- Surfaces the existing `system.text` field (from the `subtext` data template) on advantage and drawback item sheets as an editable "Detail" input
- Displays the detail text in parentheses after the trait name on actor traits tab and character creator sheet
- Adds `MEGS.Detail` localization key for EN and PT

Examples: Connection (Gotham City Police Department), Irrational Attraction (Shiny Objects)

## Test plan

- [x] Open an advantage item sheet — verify "Detail" input appears below the name
- [x] Open a drawback item sheet — verify "Detail" input appears below the name
- [x] Enter text in the Detail field, save — verify it persists
- [x] Check actor Traits tab — verify detail appears in parentheses after trait name
- [ ] Check character creator Traits tab — same parenthetical display
- [x] Verify traits without detail text show name only (no empty parentheses)
- [ ] Verify gadget traits tab also shows detail text

Fixes #209