### PR TITLE
Add gadget-only flag to advantages and drawbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Added "Gadget Only" checkbox on advantage and drawback item sheets; gadget-only traits are blocked from being dropped directly onto actor sheets (issue #178)
 - Added editable detail/subtext field on advantage and drawback item sheets, displayed in parentheses on actor traits tab and character creator (issue #209)
 - Alphabetized advantages and drawbacks on character builder sheet
 - Added post-merge hook to sync README version references automatically

--- a/lang/en.json
+++ b/lang/en.json
@@ -74,6 +74,8 @@
         "EffectValue": "Effect Value",
         "Factor": "Factor",
         "FactorCostMod": "Factor Cost Mod",
+        "GadgetOnly": "Gadget Only",
+        "GadgetOnlyWarning": "This trait can only be added to gadgets, not directly to characters.",
         "Gadgets": "Gadgets",
         "HasAVAndEV": "Has AV & EV?",
         "HasGadgets": "Has gadgets?",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -74,6 +74,8 @@
         "EffectValue": "Valor de Efeito",
         "Factor": "Fator",
         "FactorCostMod": "Modificador do fator de custo",
+        "GadgetOnly": "Apenas Equipamento",
+        "GadgetOnlyWarning": "Este traço só pode ser adicionado a equipamentos, não diretamente a personagens.",
         "Gadgets": "Equipamentos",
         "HasAVAndEV": "Possui AV e EV?",
         "HasGadgets": "Possui equipamentos?",

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -69,7 +69,8 @@ export class MEGSItem extends Item {
                             img: item.img,
                             system: {
                                 baseCost: item.system.baseCost || 0,
-                                text: item.system.text || ''
+                                text: item.system.text || '',
+                                gadgetOnly: item.system.gadgetOnly || false
                             }
                         };
                     }
@@ -549,7 +550,8 @@ export class MEGSItem extends Item {
                 system: {
                     parent: this.id, // Set parent to this gadget's ID
                     baseCost: trait.system?.baseCost || trait.baseCost || 0, // Handle both formats
-                    text: trait.system?.text || trait.text || '' // Handle both formats
+                    text: trait.system?.text || trait.text || '', // Handle both formats
+                    gadgetOnly: trait.system?.gadgetOnly || false
                 }
             };
             traits.push(traitObj);

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -997,6 +997,21 @@ export class MEGSActorSheet extends ActorSheet {
         super._onDrop(event);
     }
 
+    /** @override **/
+    async _onDropItemCreate(itemData) {
+        const items = Array.isArray(itemData) ? itemData : [itemData];
+        const blocked = items.filter(
+            (i) => (i.type === 'advantage' || i.type === 'drawback') && i.system?.gadgetOnly
+        );
+        if (blocked.length) {
+            ui.notifications.warn(game.i18n.localize('MEGS.GadgetOnlyWarning'));
+            const allowed = items.filter((i) => !blocked.includes(i));
+            if (!allowed.length) return false;
+            return super._onDropItemCreate(allowed);
+        }
+        return super._onDropItemCreate(itemData);
+    }
+
     _changeEditHeaderLink(sheetHeaderLinks) {
         const found = sheetHeaderLinks.find((element) => element.label === 'Sheet');
         found.icon = 'fas fa-file';

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -150,6 +150,10 @@ export class MEGSItemSheet extends ItemSheet {
 
         context.hasActor = !!this.object.parent;
 
+        if (itemData.type === MEGS.itemTypes.advantage || itemData.type === MEGS.itemTypes.drawback) {
+            context.gadgetOnlyLocked = context.hasActor && !this.object.system.parent;
+        }
+
         // if has actor parent, store powers that actor has; otherwise, store all powers
         if (itemData.type === MEGS.itemTypes.bonus || itemData.type === MEGS.itemTypes.limitation) {
             if (context.hasActor) {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/178-gadget-only-traits/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/178-gadget-only-traits/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/178-gadget-only-traits",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,

--- a/template.json
+++ b/template.json
@@ -351,7 +351,8 @@
         "advantage": {
             "templates": ["baseItem", "hasParent", "purchasable", "subtext", "trackOriginal"],
             "type": "advantage",
-            "img": "icons/svg/regen.svg"
+            "img": "icons/svg/regen.svg",
+            "gadgetOnly": false
         },
         "bonus": {
             "templates": ["baseItem", "hasParent", "modifier", "subtext", "trackOriginal"],
@@ -361,7 +362,8 @@
         "drawback": {
             "templates": ["baseItem", "hasParent", "purchasable", "subtext", "trackOriginal"],
             "type": "drawback",
-            "img": "icons/svg/degen.svg"
+            "img": "icons/svg/degen.svg",
+            "gadgetOnly": false
         },
         "gadget": {
             "templates": [

--- a/templates/item/item-advantage-sheet.hbs
+++ b/templates/item/item-advantage-sheet.hbs
@@ -10,20 +10,18 @@
             {{!-- Item name --}}
             {{> "systems/megs/templates/item/parts/item-header-name.hbs"}}
 
-            {{#if system.hasSubtext}}
-                <div class="resource flex-group-center">
-                    <label for="system.text" class="resource-label">{{localize 'MEGS.Detail'}}</label>
-                    <div class="resource-content flexrow flex-center flex-between">
-                        {{#if flags.megs.edit-mode}}
+            {{#if flags.megs.edit-mode}}
+                {{#if system.hasSubtext}}
+                    <div class="resource flex-group-center">
+                        <label for="system.text" class="resource-label">{{localize 'MEGS.Detail'}}</label>
+                        <div class="resource-content flexrow flex-center flex-between">
                             <input type="text" name="system.text" value="{{system.text}}" />
-                        {{else}}
-                            <span>{{system.text}}</span>
-                        {{/if}}
+                        </div>
                     </div>
-                </div>
+                {{/if}}
             {{/if}}
 
-            <div class="resources grid grid-2col">
+            <div class="resources grid grid-3col">
 
                 <div class="resource flex-group-center">
                     <label for="system.baseCost" class="resource-label">{{localize 'MEGS.InitialCost'}}</label>
@@ -40,6 +38,17 @@
                     <label for="system.purchaseCost" class="resource-label">{{localize 'MEGS.PurchaseCost'}}</label>
                     <div class="resource-content flexrow flex-center flex-between">
                         <span>{{multiply system.baseCost 5}}</span>
+                    </div>
+                </div>
+
+                <div class="resource flex-group-center">
+                    <label for="system.gadgetOnly" class="resource-label">{{localize 'MEGS.GadgetOnly'}}</label>
+                    <div class="resource-content flexrow flex-center" style="justify-content: center;">
+                        {{#if flags.megs.edit-mode}}
+                            <input type="checkbox" name="system.gadgetOnly" {{checked system.gadgetOnly}} />
+                        {{else}}
+                            <span>{{#if system.gadgetOnly}}Yes{{else}}No{{/if}}</span>
+                        {{/if}}
                     </div>
                 </div>
 

--- a/templates/item/item-advantage-sheet.hbs
+++ b/templates/item/item-advantage-sheet.hbs
@@ -45,7 +45,7 @@
                     <label for="system.gadgetOnly" class="resource-label">{{localize 'MEGS.GadgetOnly'}}</label>
                     <div class="resource-content flexrow flex-center" style="justify-content: center;">
                         {{#if flags.megs.edit-mode}}
-                            <input type="checkbox" name="system.gadgetOnly" {{checked system.gadgetOnly}} />
+                            <input type="checkbox" name="system.gadgetOnly" {{checked system.gadgetOnly}} {{#if gadgetOnlyLocked}}disabled{{/if}} />
                         {{else}}
                             <span>{{#if system.gadgetOnly}}Yes{{else}}No{{/if}}</span>
                         {{/if}}

--- a/templates/item/item-drawback-sheet.hbs
+++ b/templates/item/item-drawback-sheet.hbs
@@ -19,7 +19,7 @@
                 </div>
             {{/if}}
 
-            <div class="resources grid grid-2col">
+            <div class="resources grid grid-3col">
 
                 <div class="resource flex-group-center">
                     <label for="system.baseCost" class="resource-label">{{localize 'MEGS.InitialBonus'}}</label>
@@ -32,6 +32,13 @@
                     <label for="system.buybackCost" class="resource-label">{{localize 'MEGS.BuybackCost'}}</label>
                     <div class="resource-content flexrow flex-center flex-between">
                         <span>{{multiply system.baseCost 5}}</span>
+                    </div>
+                </div>
+
+                <div class="resource flex-group-center">
+                    <label for="system.gadgetOnly" class="resource-label">{{localize 'MEGS.GadgetOnly'}}</label>
+                    <div class="resource-content flexrow flex-center" style="justify-content: center;">
+                        <input type="checkbox" name="system.gadgetOnly" {{checked system.gadgetOnly}} />
                     </div>
                 </div>
 

--- a/templates/item/item-drawback-sheet.hbs
+++ b/templates/item/item-drawback-sheet.hbs
@@ -38,7 +38,7 @@
                 <div class="resource flex-group-center">
                     <label for="system.gadgetOnly" class="resource-label">{{localize 'MEGS.GadgetOnly'}}</label>
                     <div class="resource-content flexrow flex-center" style="justify-content: center;">
-                        <input type="checkbox" name="system.gadgetOnly" {{checked system.gadgetOnly}} />
+                        <input type="checkbox" name="system.gadgetOnly" {{checked system.gadgetOnly}} {{#if gadgetOnlyLocked}}disabled{{/if}} />
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary

- Adds `gadgetOnly` boolean field to advantage and drawback item data model
- Displays "Gadget Only" as a third column alongside Initial Cost and Purchase Cost on item sheets (checkbox in edit mode, Yes/No text in read-only mode)
- Checkbox is disabled/grayed out on traits owned by a non-gadget actor
- Blocks gadget-only traits from being dropped directly onto actor sheets with a warning notification
- Detail field on item sheets now only appears in edit mode
- Field preserved through gadget serialization and trait transfer
- Adds localization keys for EN and PT

## Test plan

- [x] Advantage item sheet shows "Gadget Only" as third column in header
- [x] Checkbox is centered below the label
- [x] Drawback item sheet shows same layout
- [x] Detail field hidden in non-edit mode, visible in edit mode
- [x] Dropping a gadget-only trait onto an actor sheet is blocked (returns false)
- [x] Warning notification displays when drop is blocked
- [x] Normal (non-gadgetOnly) traits still drop successfully onto actors
- [x] `gadgetOnly` field defaults to `false` on existing items
- [x] Checkbox is disabled on actor-owned non-gadget traits
- [x] Gadget-only traits can still be dropped onto gadget sheets
- [ ] `gadgetOnly` preserved when dragging gadgets between actors/sidebar
- [x] All 74 tests pass

Fixes #178