### PR TITLE
Add token avatar and smaller timestamp to chat messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Added token image to chat message headers and reduced timestamp font size (issue #93)
 - Added "On Creation Only" checkbox on advantage and drawback item sheets; creation-only traits are blocked from being dropped on actor sheets but allowed on the character creator (issue #3)
 - Added Options tab on advantage and drawback item sheets for Gadget Only and On Creation Only checkboxes; moved Gadget Only from header to Options tab (issue #3, #178)
 - Added "Gadget Only" checkbox on advantage and drawback item sheets; gadget-only traits are blocked from being dropped directly onto actor sheets (issue #178)

--- a/css/megs.css
+++ b/css/megs.css
@@ -1577,6 +1577,7 @@ li.chat-message {
   background: #fff !important;
   font-family: "Roboto", sans-serif !important;
   letter-spacing: normal !important;
+  overflow: visible !important;
   /* Tooltip styles for chat messages */
   /* Initiative/Column Shift Table in tooltip */
 }
@@ -1639,17 +1640,22 @@ li.chat-message .message-header {
   background-color: #1f5079 !important;
   color: #fff !important;
   padding: 5px !important;
+  overflow: visible !important;
+  position: relative;
+  z-index: 1;
 }
 li.chat-message .message-header .message-sender {
   display: flex;
   align-items: center;
   gap: 6px;
   color: #fff !important;
+  overflow: visible;
 }
 li.chat-message .message-header .message-sender .megs-chat-avatar {
-  width: 28px;
-  height: 28px;
-  border: 1px solid #fff;
+  width: 42px;
+  height: 42px;
+  margin: -11px 0 -11px -5px;
+  border: 2px solid #1f5079;
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;

--- a/css/megs.css
+++ b/css/megs.css
@@ -1641,13 +1641,25 @@ li.chat-message .message-header {
   padding: 5px !important;
 }
 li.chat-message .message-header .message-sender {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   color: #fff !important;
+}
+li.chat-message .message-header .message-sender .megs-chat-avatar {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #fff;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
 }
 li.chat-message .message-header .message-metadata {
   color: #fff !important;
 }
 li.chat-message .message-header .message-metadata .message-timestamp {
   color: #fff !important;
+  font-size: 10px;
 }
 li.chat-message .message-header .message-metadata .message-delete {
   color: #fff !important;

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -1328,6 +1328,30 @@ Hooks.once('ready', async function () {
     });
     Hooks.on('chatMessage', (log, message, data) => interceptMegsRoll(message, data));
 
+    Hooks.on('renderChatMessage', (message, html) => {
+        const { scene: sceneId, token: tokenId, actor: actorId } = message.speaker;
+        const actor = game.scenes.get(sceneId)?.tokens.get(tokenId)?.actor
+            ?? game.actors.get(actorId);
+        if (!actor) return;
+
+        const tokenImg = game.scenes.get(sceneId)?.tokens.get(tokenId)?.texture.src
+            ?? actor.prototypeToken?.texture?.src
+            ?? actor.img;
+        if (!tokenImg) return;
+
+        const header = html[0]?.querySelector?.('.message-header') ?? html.querySelector?.('.message-header');
+        if (!header) return;
+
+        const sender = header.querySelector('.message-sender');
+        if (!sender || sender.querySelector('.megs-chat-avatar')) return;
+
+        const img = document.createElement('img');
+        img.classList.add('megs-chat-avatar');
+        img.src = tokenImg;
+        img.alt = actor.name;
+        sender.prepend(img);
+    });
+
     // Hook to preserve gadget power/skill data when dragging from sidebar to actor
     Hooks.on('preCreateItem', (item, data, options, userId) => {
         if (item.type === 'gadget' && item.parent && data.flags?.megs?._transferData) {

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -44,6 +44,36 @@ Hooks.once('init', function () {
     // Register custom Roll class
     CONFIG.Dice.rolls.push(MegsRoll);
 
+    Hooks.on('renderChatMessage', (message, html) => {
+        const { scene: sceneId, token: tokenId, actor: actorId } = message.speaker;
+        const actor = game.scenes?.get(sceneId)?.tokens.get(tokenId)?.actor
+            ?? game.actors?.get(actorId);
+        if (!actor) return;
+
+        const tokenImg = game.scenes?.get(sceneId)?.tokens.get(tokenId)?.texture.src
+            ?? actor.prototypeToken?.texture?.src
+            ?? actor.img;
+        if (!tokenImg) return;
+
+        const header = html[0]?.querySelector?.('.message-header') ?? html.querySelector?.('.message-header');
+        if (!header) return;
+
+        const sender = header.querySelector('.message-sender');
+        if (!sender || sender.querySelector('.megs-chat-avatar')) return;
+
+        const tokenName = game.scenes?.get(sceneId)?.tokens.get(tokenId)?.name
+            ?? actor.prototypeToken?.name;
+        if (tokenName && tokenName !== actor.name) {
+            sender.textContent = sender.textContent.replace(actor.name, tokenName);
+        }
+
+        const img = document.createElement('img');
+        img.classList.add('megs-chat-avatar');
+        img.src = tokenImg;
+        img.alt = tokenName || actor.name;
+        sender.prepend(img);
+    });
+
     // Load MEGS tables
     _loadData('systems/megs/assets/data/tables.json').then((data) => {
         if (data) {
@@ -1327,30 +1357,6 @@ Hooks.once('ready', async function () {
         }
     });
     Hooks.on('chatMessage', (log, message, data) => interceptMegsRoll(message, data));
-
-    Hooks.on('renderChatMessage', (message, html) => {
-        const { scene: sceneId, token: tokenId, actor: actorId } = message.speaker;
-        const actor = game.scenes.get(sceneId)?.tokens.get(tokenId)?.actor
-            ?? game.actors.get(actorId);
-        if (!actor) return;
-
-        const tokenImg = game.scenes.get(sceneId)?.tokens.get(tokenId)?.texture.src
-            ?? actor.prototypeToken?.texture?.src
-            ?? actor.img;
-        if (!tokenImg) return;
-
-        const header = html[0]?.querySelector?.('.message-header') ?? html.querySelector?.('.message-header');
-        if (!header) return;
-
-        const sender = header.querySelector('.message-sender');
-        if (!sender || sender.querySelector('.megs-chat-avatar')) return;
-
-        const img = document.createElement('img');
-        img.classList.add('megs-chat-avatar');
-        img.src = tokenImg;
-        img.alt = actor.name;
-        sender.prepend(img);
-    });
 
     // Hook to preserve gadget power/skill data when dragging from sidebar to actor
     Hooks.on('preCreateItem', (item, data, options, userId) => {

--- a/src/scss/components/_chat.scss
+++ b/src/scss/components/_chat.scss
@@ -80,7 +80,19 @@ li.chat-message {
         padding: 5px !important;
 
         .message-sender {
+            display: flex;
+            align-items: center;
+            gap: 6px;
             color: $c-white !important;
+
+            .megs-chat-avatar {
+                width: 28px;
+                height: 28px;
+                border: 1px solid $c-white;
+                border-radius: 50%;
+                object-fit: cover;
+                flex-shrink: 0;
+            }
         }
 
         .message-metadata {
@@ -88,6 +100,7 @@ li.chat-message {
 
             .message-timestamp {
                 color: $c-white !important;
+                font-size: 10px;
             }
 
             .message-delete {

--- a/src/scss/components/_chat.scss
+++ b/src/scss/components/_chat.scss
@@ -6,6 +6,7 @@ li.chat-message {
     background: $c-white !important;
     font-family: $font-primary !important;
     letter-spacing: normal !important;
+    overflow: visible !important;
 
     .message-content {
         background: $c-white !important;
@@ -78,17 +79,22 @@ li.chat-message {
         background-color: $c-darkblue !important;
         color: $c-white !important;
         padding: 5px !important;
+        overflow: visible !important;
+        position: relative;
+        z-index: 1;
 
         .message-sender {
             display: flex;
             align-items: center;
             gap: 6px;
             color: $c-white !important;
+            overflow: visible;
 
             .megs-chat-avatar {
-                width: 28px;
-                height: 28px;
-                border: 1px solid $c-white;
+                width: 42px;
+                height: 42px;
+                margin: -11px 0 -11px -5px;
+                border: 2px solid $c-darkblue;
                 border-radius: 50%;
                 object-fit: cover;
                 flex-shrink: 0;

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/93-chat-token-image/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/93-chat-token-image/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/93-chat-token-image",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary

- Show the actor's token image as a circular avatar to the left of the sender name in chat message headers
- Reduce timestamp font size to 10px
- Display token/prototype token name in chat when it differs from the actor sheet name
- Avatar overflows the header bar with dark blue border for a polished look

Fixes #93

## Test plan

- [x] Chat messages from rolls show the actor's token image to the left of the sender name
- [x] Token avatars persist after browser refresh (not just on new messages)
- [x] Avatar extends above and below the dark blue header bar without being clipped
- [x] Timestamp text is visibly smaller than the sender name
- [x] If a token's name differs from its actor sheet name, the token name is shown in chat
- [x] Messages from actors without tokens (e.g., GM chat) render normally without errors
- [x] Avatar border matches the dark blue header color