### PR TITLE
Add Playwright e2e test suite covering all #226 categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,10 @@ scripts/*
 !scripts/build-compendiums.mjs
 !scripts/extract-compendiums.mjs
 
+# Playwright
+e2e/.auth/
+test-results/
+playwright-report/
+
 # Claude Code
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ scripts/*
 e2e/.auth/
 test-results/
 playwright-report/
+e2e-*.log
+e2e/debug-*.png
 
 # Claude Code
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@
 - Fixed `ReferenceError` in `compare` Handlebars helper — added missing `options` parameter (issue #215)
 - Fixed trailing slash in system.json download URL that prevented Foundry from resolving the package
 
+### Testing
+
+- Added Playwright E2E test suite with 62 tests across 8 spec files covering all 1.0.1 milestone features (issue #226)
+- Configured Playwright with global setup for Foundry login, shared fixtures, and serial execution
+- Converted 3 existing ad-hoc E2E tests to Playwright: gadget rolling (#17), gadget sheet rolling (#13), power roll sources (#56)
+- Added new E2E tests for: trait subtext (#209), trait drop blocking (#178, #3), chat message formatting (#93), accordion state persistence (#67), reliability number (#8)
+
 ### Code Quality
 
 - Configured ESLint and Stylelint with project-specific rules and added lint CI workflow (issue #214)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,22 +1,66 @@
 # MEGS E2E Tests
 
-End-to-end tests for the MEGS Foundry VTT game system using Playwright MCP.
+End-to-end tests for the MEGS Foundry VTT game system using [Playwright](https://playwright.dev/).
 
 ## Prerequisites
 
+- Node.js 18+
 - Foundry VTT running at `http://localhost:30000` with a MEGS world loaded
-- Logged in as Gamemaster
-- Playwright MCP plugin available in Claude Code
+- A Gamemaster user configured in the world
 
-## Test Files
+## Setup
 
-- `gadget-rolling.spec.mjs` — Tests for Issue #17 (Gadgets - Rolling)
-- `gadget-sheet-rolling.spec.mjs` — Tests for Issue #13 (Roll attacks from gadget sheet)
+```bash
+npm install
+npx playwright install chromium
+```
 
 ## Running Tests
 
-These tests are designed to be run via Playwright MCP in Claude Code sessions.
-Each test creates its own temporary actors/gadgets and cleans up after itself.
+Start Foundry VTT, then:
 
-All test actors are prefixed with `_E2E_GadgetTest_` so they can be identified
-and cleaned up manually if a test fails mid-run.
+```bash
+npm run test:e2e
+```
+
+Run a single test file:
+
+```bash
+npx playwright test --config=playwright.config.mjs gadget-rolling
+```
+
+Run tests matching a pattern:
+
+```bash
+npx playwright test --config=playwright.config.mjs --grep "Default power"
+```
+
+## How It Works
+
+- **Global setup** (`fixtures/global-setup.mjs`) logs into Foundry as Gamemaster and saves the session to `e2e/.auth/state.json` (gitignored). This runs once before all tests.
+- **Test fixture** (`fixtures/foundry-test.mjs`) navigates to `/game`, waits for `game.ready`, and closes all Foundry windows after each test.
+- **Shared helpers** (`fixtures/test-data.mjs`, `fixtures/roll-helpers.mjs`) provide actor/item creation, sheet management, and roll dialog interaction.
+- Tests run serially (`workers: 1`) because Foundry VTT is single-user.
+
+## Test Data Conventions
+
+- All test actors are prefixed with `_E2E_` so they can be identified and cleaned up.
+- Each test file creates its own temporary data and cleans up in `afterAll`.
+- Global setup also cleans up any leftover `_E2E_` actors from previous failed runs.
+
+## Test Files
+
+| File | Issue | Tests | Description |
+|------|-------|-------|-------------|
+| `gadget-rolling.spec.mjs` | #17 | 23 | Gadget rolling from actor sheet |
+| `gadget-sheet-rolling.spec.mjs` | #13 | 9 | Roll from gadget item sheet |
+| `power-roll-sources.spec.mjs` | #56 | 9 | Power AV/EV/OV/RV source overrides |
+| `trait-subtext.spec.mjs` | #209 | 5 | Trait detail/subtext display |
+| `trait-drop-blocking.spec.mjs` | #178, #3 | 5 | Gadget-only and creation-only drop blocking |
+| `chat-message-formatting.spec.mjs` | #93 | 4 | Chat message avatar and formatting |
+| `accordion-state.spec.mjs` | #67 | 3 | Accordion expand/collapse persistence |
+| `reliability-number.spec.mjs` | #8 | 4 | Reliability number display and cost |
+
+## Legacy Tests
+
+The `legacy/` directory contains the original ad-hoc E2E tests that were designed for MCP browser control. They are preserved for reference but are not part of the Playwright test suite.

--- a/e2e/fixtures/foundry-test.mjs
+++ b/e2e/fixtures/foundry-test.mjs
@@ -1,17 +1,34 @@
 import { test as base, expect } from '@playwright/test';
 
 export const test = base.extend({
-    gameReady: [async ({ page }, use) => {
-        await page.goto('/game');
+    // Worker-scoped: one browser context and page shared by every test in the
+    // worker, so the Foundry world loads once instead of once per test.
+    workerPage: [async ({ browser }, use) => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        await page.goto('/game', { timeout: 60_000 });
         await page.waitForFunction(
             () => typeof game !== 'undefined' && game.ready === true,
-            { timeout: 30_000 }
+            null,
+            { timeout: 60_000 }
         );
         await use(page);
-        await page.evaluate(() => {
+        await context.close();
+    }, { scope: 'worker' }],
+
+    // Every test's `page` is the shared worker page; close any Foundry
+    // windows a test left open before handing it to the next test.
+    page: async ({ workerPage }, use) => {
+        await use(workerPage);
+        await workerPage.evaluate(() => {
             Object.values(ui.windows).forEach(w => w.close());
-        });
-    }, { auto: true }],
+        }).catch(() => {});
+        await workerPage.waitForFunction(
+            () => Object.keys(ui.windows).length === 0,
+            null,
+            { timeout: 5000 }
+        ).catch(() => {});
+    },
 });
 
 export { expect };

--- a/e2e/fixtures/foundry-test.mjs
+++ b/e2e/fixtures/foundry-test.mjs
@@ -1,0 +1,17 @@
+import { test as base, expect } from '@playwright/test';
+
+export const test = base.extend({
+    gameReady: [async ({ page }, use) => {
+        await page.goto('/game');
+        await page.waitForFunction(
+            () => typeof game !== 'undefined' && game.ready === true,
+            { timeout: 30_000 }
+        );
+        await use(page);
+        await page.evaluate(() => {
+            Object.values(ui.windows).forEach(w => w.close());
+        });
+    }, { auto: true }],
+});
+
+export { expect };

--- a/e2e/fixtures/global-setup.mjs
+++ b/e2e/fixtures/global-setup.mjs
@@ -1,0 +1,48 @@
+import { chromium } from '@playwright/test';
+import { mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+const AUTH_FILE = './e2e/.auth/state.json';
+
+export default async function globalSetup() {
+    mkdirSync(dirname(AUTH_FILE), { recursive: true });
+
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto('http://localhost:30000/game');
+    await page.waitForURL('**/join', { timeout: 10_000 });
+
+    const gmOption = await page.$('select[name="userid"] option');
+    if (!gmOption) {
+        throw new Error('No users found on join page — is Foundry running with a world loaded?');
+    }
+
+    await page.evaluate(() => {
+        const select = document.querySelector('select[name="userid"]');
+        const options = Array.from(select.options);
+        const gm = options.find(o => o.text.includes('Gamemaster') || o.text.includes('gamemaster'));
+        if (gm) {
+            select.value = gm.value;
+            select.dispatchEvent(new Event('change'));
+        }
+    });
+
+    await page.locator('button[name="join"], button[type="submit"]').first().click();
+
+    await page.waitForFunction(
+        () => typeof game !== 'undefined' && game.ready === true,
+        { timeout: 30_000 }
+    );
+
+    await page.evaluate(async () => {
+        const e2eActors = game.actors.filter(a => a.name.startsWith('_E2E_'));
+        for (const actor of e2eActors) {
+            await actor.delete();
+        }
+    });
+
+    await context.storageState({ path: AUTH_FILE });
+    await browser.close();
+}

--- a/e2e/fixtures/global-setup.mjs
+++ b/e2e/fixtures/global-setup.mjs
@@ -3,39 +3,36 @@ import { mkdirSync } from 'fs';
 import { dirname } from 'path';
 
 const AUTH_FILE = './e2e/.auth/state.json';
+const WORLD_ID = 'megs-test-world';
 
 export default async function globalSetup() {
     mkdirSync(dirname(AUTH_FILE), { recursive: true });
 
-    const browser = await chromium.launch();
+    const browser = await chromium.launch({ headless: false });
     const context = await browser.newContext();
     const page = await context.newPage();
 
-    await page.goto('http://localhost:30000/game');
-    await page.waitForURL('**/join', { timeout: 10_000 });
+    await page.goto('http://localhost:30000');
+    await page.waitForLoadState('domcontentloaded');
 
-    const gmOption = await page.$('select[name="userid"] option');
-    if (!gmOption) {
-        throw new Error('No users found on join page — is Foundry running with a world loaded?');
+    // If on setup page, launch the test world
+    if (page.url().includes('/setup')) {
+        await page.locator(`li:has(h3:has-text("MEGS Test World")) a[data-action="worldLaunch"]`).click({ force: true });
+        await page.waitForURL('**/join', { timeout: 60_000 });
     }
 
-    await page.evaluate(() => {
-        const select = document.querySelector('select[name="userid"]');
-        const options = Array.from(select.options);
-        const gm = options.find(o => o.text.includes('Gamemaster') || o.text.includes('gamemaster'));
-        if (gm) {
-            select.value = gm.value;
-            select.dispatchEvent(new Event('change'));
-        }
-    });
-
-    await page.locator('button[name="join"], button[type="submit"]').first().click();
+    // Select Gamemaster and join
+    await page.waitForSelector('select[name="userid"]', { timeout: 60_000 });
+    await page.locator('select[name="userid"]').selectOption({ label: 'Gamemaster' });
+    await page.locator('button:has-text("Join Game Session")').click();
 
     await page.waitForFunction(
         () => typeof game !== 'undefined' && game.ready === true,
-        { timeout: 30_000 }
+        null,
+        { timeout: 60_000 }
     );
 
+    // Clean up leftover test actors
     await page.evaluate(async () => {
         const e2eActors = game.actors.filter(a => a.name.startsWith('_E2E_'));
         for (const actor of e2eActors) {

--- a/e2e/fixtures/roll-helpers.mjs
+++ b/e2e/fixtures/roll-helpers.mjs
@@ -1,0 +1,106 @@
+export async function isRollDialogOpen(page) {
+    return page.evaluate(() => {
+        for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
+            if (d.querySelector('#actionValue')) return true;
+        }
+        return false;
+    });
+}
+
+export async function waitForRollDialog(page) {
+    await page.waitForSelector('.dialog .megs-dialog #actionValue', { timeout: 5000 });
+}
+
+export async function getRollDialogValues(page) {
+    return page.evaluate(() => {
+        const av = document.querySelector('.dialog .megs-dialog #actionValue');
+        const ev = document.querySelector('.dialog .megs-dialog #effectValue');
+        return {
+            actionValue: av ? Number.parseInt(av.value) : null,
+            effectValue: ev ? Number.parseInt(ev.value) : null,
+        };
+    });
+}
+
+export async function closeRollDialog(page) {
+    await page.evaluate(() => {
+        for (const btn of document.querySelectorAll('.dialog button')) {
+            if (btn.textContent.includes('Close')) { btn.click(); return; }
+        }
+    });
+    await page.waitForFunction(
+        () => !document.querySelector('.dialog .megs-dialog #actionValue'),
+        { timeout: 5000 }
+    );
+}
+
+export async function submitRollDialog(page, beforeCount) {
+    await page.evaluate(() => {
+        for (const btn of document.querySelectorAll('.dialog button')) {
+            const text = btn.textContent.trim();
+            if (text === 'Roll' || text === 'Submit') { btn.click(); return; }
+        }
+    });
+    await page.waitForFunction(
+        (before) => document.querySelectorAll('#chat-log .chat-message').length > before,
+        { timeout: 10000 },
+        beforeCount
+    );
+}
+
+export async function isPickerDialogOpen(page) {
+    return page.evaluate(() => {
+        for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
+            if (d.querySelector('input[name="selectedOption"]')) return true;
+        }
+        return false;
+    });
+}
+
+export async function getPickerOptions(page) {
+    return page.$$eval(
+        '.dialog .megs-dialog .gadget-roll-option span',
+        (spans) => spans.map(s => s.textContent.trim())
+    );
+}
+
+export async function selectPickerOptionAndRoll(page, index) {
+    await page.evaluate((idx) => {
+        const radios = document.querySelectorAll('.dialog .megs-dialog input[name="selectedOption"]');
+        if (radios[idx]) radios[idx].checked = true;
+    }, index);
+    await page.click('.dialog button:has-text("Roll")');
+    await page.waitForSelector('.dialog .megs-dialog #actionValue', { timeout: 5000 });
+}
+
+export async function cancelPickerDialog(page) {
+    await page.evaluate(() => {
+        for (const btn of document.querySelectorAll('.dialog button')) {
+            if (btn.textContent.includes('Close')) { btn.click(); return; }
+        }
+        const x = document.querySelector('.dialog .header-button.close');
+        if (x) x.click();
+    });
+    await page.waitForFunction(
+        () => !document.querySelector('.dialog .megs-dialog input[name="selectedOption"]'),
+        { timeout: 5000 }
+    );
+}
+
+export async function getChatMessageCount(page) {
+    return page.evaluate(() => document.querySelectorAll('#chat-log .chat-message').length);
+}
+
+export async function getLatestChatMessage(page) {
+    return page.evaluate(() => {
+        const msgs = document.querySelectorAll('#chat-log .chat-message');
+        if (!msgs.length) return null;
+        const msg = msgs[msgs.length - 1];
+        const header = msg.querySelector('.message-header h4');
+        return {
+            header: header?.textContent?.trim() || null,
+            html: msg.innerHTML,
+            classes: Array.from(msg.classList),
+        };
+    });
+}

--- a/e2e/fixtures/roll-helpers.mjs
+++ b/e2e/fixtures/roll-helpers.mjs
@@ -1,4 +1,4 @@
-export async function isRollDialogOpen(page) {
+﻿export async function isRollDialogOpen(page) {
     return page.evaluate(() => {
         for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
             if (d.querySelector('#actionValue')) return true;
@@ -30,6 +30,7 @@ export async function closeRollDialog(page) {
     });
     await page.waitForFunction(
         () => !document.querySelector('.dialog .megs-dialog #actionValue'),
+        null,
         { timeout: 5000 }
     );
 }
@@ -42,9 +43,9 @@ export async function submitRollDialog(page, beforeCount) {
         }
     });
     await page.waitForFunction(
-        (before) => document.querySelectorAll('#chat-log .chat-message').length > before,
-        { timeout: 10000 },
-        beforeCount
+        (before) => document.querySelectorAll('.chat-log .chat-message').length > before,
+        beforeCount,
+        { timeout: 10000 }
     );
 }
 
@@ -83,17 +84,158 @@ export async function cancelPickerDialog(page) {
     });
     await page.waitForFunction(
         () => !document.querySelector('.dialog .megs-dialog input[name="selectedOption"]'),
+        null,
         { timeout: 5000 }
     );
 }
 
+/**
+ * Queue deterministic d10 results. Overrides Die.prototype.randomFace so the
+ * next rolls consume the queued face values in order; once the queue is empty,
+ * rolling falls back to real randomness. Also silences Dice So Nice so chat
+ * messages appear immediately and doubles-confirm dialogs are not delayed
+ * by 3D animations.
+ */
+export async function queueDice(page, values) {
+    await page.evaluate((vals) => {
+        const DieCls = foundry.dice.terms.Die;
+        if (!window._e2eDice) {
+            window._e2eDice = {
+                origRandomFace: DieCls.prototype.randomFace,
+                origShowForRoll: game.dice3d ? game.dice3d.showForRoll : null,
+                origMessageHookDisabled: game.dice3d ? game.dice3d.messageHookDisabled : null,
+            };
+        }
+        window._e2eDiceQueue = vals.slice();
+        DieCls.prototype.randomFace = function () {
+            const q = window._e2eDiceQueue;
+            if (q && q.length) return q.shift();
+            return window._e2eDice.origRandomFace.call(this);
+        };
+        if (game.dice3d) {
+            game.dice3d.messageHookDisabled = true;
+            game.dice3d.showForRoll = async () => true;
+        }
+    }, values);
+}
+
+/** Restore real dice randomness and Dice So Nice behavior. */
+export async function restoreDice(page) {
+    await page.evaluate(() => {
+        if (!window._e2eDice) return;
+        foundry.dice.terms.Die.prototype.randomFace = window._e2eDice.origRandomFace;
+        if (game.dice3d) {
+            game.dice3d.showForRoll = window._e2eDice.origShowForRoll;
+            game.dice3d.messageHookDisabled = window._e2eDice.origMessageHookDisabled;
+        }
+        window._e2eDice = null;
+        window._e2eDiceQueue = null;
+    });
+}
+
+/**
+ * Fill fields in the open MEGS roll dialog. All parameters optional;
+ * only provided values are changed.
+ */
+export async function fillRollDialog(page, { av, ev, ov, rv, maneuver, resultShifts } = {}) {
+    await page.evaluate(({ av, ev, ov, rv, maneuver, resultShifts }) => {
+        const dialog = document.querySelector('.dialog .megs-dialog');
+        if (!dialog) throw new Error('Roll dialog not open');
+        const set = (sel, value) => {
+            const el = dialog.querySelector(sel);
+            if (!el) throw new Error('Roll dialog field not found: ' + sel);
+            el.value = String(value);
+        };
+        if (av !== undefined) set('#actionValue', av);
+        if (ev !== undefined) set('#effectValue', ev);
+        if (ov !== undefined) set('#opposingValue', ov);
+        if (rv !== undefined) set('#resistanceValue', rv);
+        if (resultShifts !== undefined) set('#resultColumnShiftsInput', resultShifts);
+        if (maneuver !== undefined) {
+            const select = dialog.querySelector('select[name="combatManeuver"]');
+            if (!select) throw new Error('Combat maneuver select not found');
+            select.value = maneuver;
+        }
+    }, { av, ev, ov, rv, maneuver, resultShifts });
+}
+
+/** Click Submit in the roll dialog without waiting for a chat message. */
+export async function clickRollDialogSubmit(page) {
+    await page.evaluate(() => {
+        for (const btn of document.querySelectorAll('.dialog button')) {
+            const text = btn.textContent.trim();
+            if (text === 'Roll' || text === 'Submit') { btn.click(); return; }
+        }
+        throw new Error('Submit button not found in roll dialog');
+    });
+}
+
+/**
+ * Answer the "Continue Rolling?" doubles confirmation dialog.
+ * Waits for the dialog to appear, then clicks Yes or No.
+ */
+export async function answerDoublesPrompt(page, continueRolling) {
+    // Answered dialogs are tagged with data-e2e-answered so consecutive
+    // prompts are not confused with a prior dialog that is still closing.
+    await page.waitForFunction(
+        () => [...document.querySelectorAll('.dialog')].some(d =>
+            !d.dataset.e2eAnswered &&
+            [...d.querySelectorAll('.window-title, h4')].some(el => el.textContent.includes('Continue Rolling'))),
+        null,
+        { timeout: 10000 }
+    );
+    await page.evaluate((yes) => {
+        const dialog = [...document.querySelectorAll('.dialog')].find(d =>
+            !d.dataset.e2eAnswered &&
+            [...d.querySelectorAll('.window-title, h4')].some(el => el.textContent.includes('Continue Rolling')));
+        if (!dialog) throw new Error('Doubles confirm dialog not found');
+        dialog.dataset.e2eAnswered = '1';
+        const label = yes ? 'Yes' : 'No';
+        for (const btn of dialog.querySelectorAll('button')) {
+            if (btn.textContent.trim().includes(label)) { btn.click(); return; }
+        }
+        throw new Error('Button not found in doubles dialog: ' + label);
+    }, continueRolling);
+}
+
+/**
+ * Parse the most recent MEGS roll chat message into structured data:
+ * difficulty, dice faces, roll total, result text, effect table result,
+ * and success/failure styling.
+ */
+export async function parseLatestRollMessage(page) {
+    return page.evaluate(() => {
+        const msgs = document.querySelectorAll('.chat-log .chat-message');
+        if (!msgs.length) return null;
+        const msg = msgs[msgs.length - 1];
+        const text = msg.textContent;
+
+        const difficultyMatch = text.match(/Difficulty:\s*(\d+)/);
+        const totalMatch = text.match(/=\s*(\d+)/);
+        const evResultMatch = text.match(/Effect table result:\s*([^\n]+)/);
+        const dice = [...msg.querySelectorAll('.d10')].map(d => Number.parseInt(d.textContent.trim()));
+
+        const summaryResult = msg.querySelector('summary .chat-result');
+        return {
+            difficulty: difficultyMatch ? Number.parseInt(difficultyMatch[1]) : null,
+            rollTotal: totalMatch ? Number.parseInt(totalMatch[1]) : null,
+            dice,
+            evResult: evResultMatch ? evResultMatch[1].trim() : null,
+            resultText: summaryResult ? summaryResult.textContent.trim() : null,
+            isSuccess: summaryResult ? summaryResult.classList.contains('success') : null,
+            isFailure: summaryResult ? summaryResult.classList.contains('failure') : null,
+            raw: text,
+        };
+    });
+}
+
 export async function getChatMessageCount(page) {
-    return page.evaluate(() => document.querySelectorAll('#chat-log .chat-message').length);
+    return page.evaluate(() => document.querySelectorAll('.chat-log .chat-message').length);
 }
 
 export async function getLatestChatMessage(page) {
     return page.evaluate(() => {
-        const msgs = document.querySelectorAll('#chat-log .chat-message');
+        const msgs = document.querySelectorAll('.chat-log .chat-message');
         if (!msgs.length) return null;
         const msg = msgs[msgs.length - 1];
         const header = msg.querySelector('.message-header h4');

--- a/e2e/fixtures/test-data.mjs
+++ b/e2e/fixtures/test-data.mjs
@@ -1,0 +1,186 @@
+const TEST_PREFIX = '_E2E_';
+
+export function prefixName(name) {
+    return TEST_PREFIX + name;
+}
+
+export async function createHeroActor(page, name, attributes = {}) {
+    return page.evaluate(async ({ name, attributes }) => {
+        const actor = await Actor.create({
+            name,
+            type: 'hero',
+            system: {
+                attributes: {
+                    dex: { value: attributes.dex || 5 },
+                    str: { value: attributes.str || 4 },
+                    body: { value: attributes.body || 4 },
+                    int: { value: attributes.int || 3 },
+                    will: { value: attributes.will || 3 },
+                    mind: { value: attributes.mind || 3 },
+                    infl: { value: attributes.infl || 2 },
+                    aura: { value: attributes.aura || 2 },
+                    spirit: { value: attributes.spirit || 2 },
+                },
+                heroPoints: { value: 10 },
+            },
+        });
+        return actor.id;
+    }, { name, attributes });
+}
+
+export async function createTargetActor(page, name, attributes = {}) {
+    return page.evaluate(async ({ name, attributes }) => {
+        const actor = await Actor.create({
+            name,
+            type: 'hero',
+            system: {
+                attributes: {
+                    dex: { value: attributes.dex || 6 },
+                    str: { value: attributes.str || 7 },
+                    body: { value: attributes.body || 8 },
+                    int: { value: attributes.int || 4 },
+                    will: { value: attributes.will || 5 },
+                    mind: { value: attributes.mind || 6 },
+                    infl: { value: attributes.infl || 3 },
+                    aura: { value: attributes.aura || 4 },
+                    spirit: { value: attributes.spirit || 5 },
+                },
+                heroPoints: { value: 10 },
+            },
+        });
+        return actor.id;
+    }, { name, attributes });
+}
+
+export async function addPowerToActor(page, actorId, powerData) {
+    return page.evaluate(async ({ actorId, powerData }) => {
+        const actor = game.actors.get(actorId);
+        const items = await actor.createEmbeddedDocuments('Item', [{
+            name: powerData.name,
+            type: 'power',
+            system: {
+                aps: powerData.aps || 8,
+                link: powerData.link || 'str',
+                source: powerData.source || 'physical',
+                type: powerData.type || 'dice',
+                avSource: powerData.avSource || '',
+                evSource: powerData.evSource || '',
+                ovSource: powerData.ovSource || '',
+                rvSource: powerData.rvSource || '',
+                parent: powerData.parent || '',
+            },
+        }]);
+        return items[0].id;
+    }, { actorId, powerData });
+}
+
+export async function addSkillToActor(page, actorId, skillData) {
+    return page.evaluate(async ({ actorId, skillData }) => {
+        const actor = game.actors.get(actorId);
+        const items = await actor.createEmbeddedDocuments('Item', [{
+            name: skillData.name,
+            type: 'skill',
+            system: {
+                aps: skillData.aps || 3,
+                link: skillData.link || 'dex',
+                parent: skillData.parent || '',
+            },
+        }]);
+        return items[0].id;
+    }, { actorId, skillData });
+}
+
+export async function addTraitToActor(page, actorId, traitData) {
+    return page.evaluate(async ({ actorId, traitData }) => {
+        const actor = game.actors.get(actorId);
+        const items = await actor.createEmbeddedDocuments('Item', [{
+            name: traitData.name,
+            type: traitData.type || 'advantage',
+            system: {
+                baseCost: traitData.baseCost || 5,
+                text: traitData.text || '',
+                gadgetOnly: traitData.gadgetOnly || false,
+                creationOnly: traitData.creationOnly || false,
+                hasSubtext: traitData.hasSubtext !== false,
+            },
+        }]);
+        return items[0].id;
+    }, { actorId, traitData });
+}
+
+export async function addGadgetToActor(page, actorId, gadgetData) {
+    return page.evaluate(async ({ actorId, gadgetData }) => {
+        const actor = game.actors.get(actorId);
+        const items = await actor.createEmbeddedDocuments('Item', [{
+            name: gadgetData.name,
+            type: 'gadget',
+            system: {
+                actionValue: gadgetData.av || 0,
+                effectValue: gadgetData.ev || 0,
+                description: gadgetData.description || '',
+                reliability: gadgetData.reliability ?? 0,
+                isBroken: gadgetData.isBroken || false,
+                attributes: {
+                    dex: { value: gadgetData.attrs?.dex || 0, label: 'DEX', alwaysSubstitute: gadgetData.attrs?.dexItalic || false },
+                    str: { value: gadgetData.attrs?.str || 0, label: 'STR', alwaysSubstitute: gadgetData.attrs?.strItalic || false },
+                    body: { value: gadgetData.attrs?.body || 0, label: 'BODY', alwaysSubstitute: gadgetData.attrs?.bodyItalic || false },
+                    int: { value: gadgetData.attrs?.int || 0, label: 'INT', alwaysSubstitute: false },
+                    will: { value: gadgetData.attrs?.will || 0, label: 'WILL', alwaysSubstitute: false },
+                    mind: { value: gadgetData.attrs?.mind || 0, label: 'MIND', alwaysSubstitute: false },
+                    infl: { value: gadgetData.attrs?.infl || 0, label: 'INFL', alwaysSubstitute: false },
+                    aura: { value: gadgetData.attrs?.aura || 0, label: 'AURA', alwaysSubstitute: false },
+                    spirit: { value: gadgetData.attrs?.spirit || 0, label: 'SPIRIT', alwaysSubstitute: false },
+                },
+                settings: { hasAttributes: gadgetData.hasAttributes ?? true },
+            },
+        }]);
+        return items[0].id;
+    }, { actorId, gadgetData });
+}
+
+export async function deleteActor(page, actorId) {
+    await page.evaluate(async (id) => {
+        const actor = game.actors.get(id);
+        if (actor) await actor.delete();
+    }, actorId);
+}
+
+export async function cleanupE2EActors(page) {
+    await page.evaluate(async (prefix) => {
+        const actors = game.actors.filter(a => a.name.startsWith(prefix));
+        for (const actor of actors) {
+            await actor.delete();
+        }
+    }, TEST_PREFIX);
+}
+
+export async function openActorSheet(page, actorId, tab) {
+    await page.evaluate(({ id, tab }) => {
+        const actor = game.actors.get(id);
+        if (!actor) throw new Error('Actor not found: ' + id);
+        actor.sheet.render(true);
+    }, { id: actorId, tab });
+    await page.waitForSelector('.sheet.actor', { timeout: 5000 });
+    if (tab) {
+        await page.click(`.sheet.actor .tabs .item[data-tab="${tab}"]`);
+        await page.waitForSelector(`.sheet.actor .tab.${tab}`, { timeout: 5000 });
+    }
+}
+
+export async function openItemSheet(page, actorId, itemId) {
+    await page.evaluate(({ actorId, itemId }) => {
+        const actor = game.actors.get(actorId);
+        if (!actor) throw new Error('Actor not found: ' + actorId);
+        const item = actor.items.get(itemId);
+        if (!item) throw new Error('Item not found: ' + itemId);
+        item.sheet.render(true);
+    }, { actorId, itemId });
+    await page.waitForSelector('.sheet.item', { timeout: 5000 });
+}
+
+export async function closeAllWindows(page) {
+    await page.evaluate(() => {
+        Object.values(ui.windows).forEach(w => w.close());
+    });
+    await page.waitForFunction(() => Object.keys(ui.windows).length === 0, { timeout: 5000 });
+}

--- a/e2e/fixtures/test-data.mjs
+++ b/e2e/fixtures/test-data.mjs
@@ -59,7 +59,9 @@ export async function addPowerToActor(page, actorId, powerData) {
             name: powerData.name,
             type: 'power',
             system: {
-                aps: powerData.aps || 8,
+                aps: powerData.aps ?? 8,
+                baseCost: powerData.baseCost ?? 0,
+                factorCost: powerData.factorCost ?? 0,
                 link: powerData.link || 'str',
                 source: powerData.source || 'physical',
                 type: powerData.type || 'dice',
@@ -81,13 +83,48 @@ export async function addSkillToActor(page, actorId, skillData) {
             name: skillData.name,
             type: 'skill',
             system: {
-                aps: skillData.aps || 3,
+                aps: skillData.aps ?? 3,
+                baseCost: skillData.baseCost ?? 0,
+                factorCost: skillData.factorCost ?? 0,
                 link: skillData.link || 'dex',
                 parent: skillData.parent || '',
             },
         }]);
         return items[0].id;
     }, { actorId, skillData });
+}
+
+export async function addSubskillToActor(page, actorId, subskillData) {
+    return page.evaluate(async ({ actorId, subskillData }) => {
+        const actor = game.actors.get(actorId);
+        const items = await actor.createEmbeddedDocuments('Item', [{
+            name: subskillData.name,
+            type: 'subskill',
+            system: {
+                aps: subskillData.aps ?? 0,
+                parent: subskillData.parent || '',
+                linkedSkill: subskillData.linkedSkill || '',
+                isTrained: subskillData.isTrained ?? false,
+            },
+        }]);
+        return items[0].id;
+    }, { actorId, subskillData });
+}
+
+/** Add a bonus or limitation item modifying the given parent item. */
+export async function addModifierToActorItem(page, actorId, modifierData) {
+    return page.evaluate(async ({ actorId, modifierData }) => {
+        const actor = game.actors.get(actorId);
+        const items = await actor.createEmbeddedDocuments('Item', [{
+            name: modifierData.name,
+            type: modifierData.type, // 'bonus' or 'limitation'
+            system: {
+                factorCostMod: modifierData.factorCostMod ?? 0,
+                parent: modifierData.parent || '',
+            },
+        }]);
+        return items[0].id;
+    }, { actorId, modifierData });
 }
 
 export async function addTraitToActor(page, actorId, traitData) {
@@ -131,7 +168,12 @@ export async function addGadgetToActor(page, actorId, gadgetData) {
                     aura: { value: gadgetData.attrs?.aura || 0, label: 'AURA', alwaysSubstitute: false },
                     spirit: { value: gadgetData.attrs?.spirit || 0, label: 'SPIRIT', alwaysSubstitute: false },
                 },
-                settings: { hasAttributes: gadgetData.hasAttributes ?? true },
+                // hasAttributes is an object of per-category string flags;
+                // templates gate the attribute section on these, not a boolean
+                settings: {
+                    hasAttributes: gadgetData.hasAttributes
+                        ?? { physical: 'true', mental: 'true', mystical: 'true' },
+                },
             },
         }]);
         return items[0].id;
@@ -179,8 +221,17 @@ export async function openItemSheet(page, actorId, itemId) {
 }
 
 export async function closeAllWindows(page) {
-    await page.evaluate(() => {
-        Object.values(ui.windows).forEach(w => w.close());
+    const forceCloseAll = () => page.evaluate(async () => {
+        for (const w of Object.values(ui.windows)) {
+            try { await w.close({ force: true }); } catch { /* mid-render close can throw */ }
+        }
     });
-    await page.waitForFunction(() => Object.keys(ui.windows).length === 0, { timeout: 5000 });
+    await forceCloseAll();
+    try {
+        await page.waitForFunction(() => Object.keys(ui.windows).length === 0, null, { timeout: 5000 });
+    } catch {
+        // A window re-rendered while closing; one retry settles it
+        await forceCloseAll();
+        await page.waitForFunction(() => Object.keys(ui.windows).length === 0, null, { timeout: 5000 });
+    }
 }

--- a/e2e/legacy/gadget-rolling.spec.mjs
+++ b/e2e/legacy/gadget-rolling.spec.mjs
@@ -1,0 +1,1096 @@
+/**
+ * E2E tests for Issue #17: Gadgets - Rolling
+ *
+ * These tests verify the REQUIREMENTS for gadget rolling behavior per MEGS RPG
+ * Chapter 7 rules, NOT the implementation. They are written adversarially
+ * to catch regressions and edge cases.
+ *
+ * All test actors and items are created fresh for each test and deleted
+ * afterward. No references to any specific IP or pre-existing world data.
+ *
+ * Requirements under test:
+ * R1. A gadget with explicit AV/EV should be rollable from the actor Gadgets tab.
+ * R2. A gadget with child powers (APs > 0) should be rollable.
+ * R3. A gadget with child skills (APs > 0) should be rollable.
+ * R4. A gadget with non-zero attribute pairs (DEX/STR, INT/WILL, INFL/AURA)
+ *     should be rollable.
+ * R5. A gadget with NONE of the above should NOT show a roll button.
+ * R6. When exactly one roll option exists, clicking the roll button should
+ *     proceed directly to the roll dialog (no picker).
+ * R7. When multiple roll options exist, clicking the roll button should open
+ *     a picker dialog listing all available options.
+ * R8. Child powers/skills with 0 APs should NOT appear as roll options.
+ * R9. The roll button tooltip should indicate what can be rolled.
+ * R10. The "Always Substitute" (italicized) checkbox should be visible in
+ *      gadget edit mode and persist when toggled.
+ * R11. A gadget macro (item.roll()) should trigger the roll flow, not just
+ *      post description text.
+ * R12. Chat messages from gadget rolls should identify both the gadget and
+ *      the specific ability rolled.
+ *
+ * Preconditions:
+ * - Foundry VTT running at http://localhost:30000 with a MEGS world loaded
+ * - Logged in as Gamemaster
+ */
+
+const FOUNDRY_URL = 'http://localhost:30000/game';
+const TEST_ACTOR_PREFIX = '_E2E_GadgetTest_';
+
+// ============================================================
+// Foundry API Helpers — create and tear down test data
+// ============================================================
+
+/**
+ * Create a fresh hero actor with the given gadgets configuration.
+ * Returns { actorId, gadgetIds: { [name]: id }, itemIds: { [name]: id } }
+ */
+async function createTestActor(page, name, gadgets) {
+    return page.evaluate(async ({ name, gadgets }) => {
+        const actor = await Actor.create({
+            name,
+            type: 'hero',
+            system: {
+                attributes: {
+                    dex: { value: 5 },
+                    str: { value: 4 },
+                    body: { value: 4 },
+                    int: { value: 3 },
+                    will: { value: 3 },
+                    mind: { value: 3 },
+                    infl: { value: 3 },
+                    aura: { value: 3 },
+                    spirit: { value: 3 },
+                },
+                heroPoints: { value: 10 },
+            },
+        });
+
+        const gadgetIds = {};
+        const itemIds = {};
+
+        for (const g of gadgets) {
+            const gadgetData = {
+                name: g.name,
+                type: 'gadget',
+                system: {
+                    actionValue: g.av || 0,
+                    effectValue: g.ev || 0,
+                    description: g.description || '',
+                    attributes: {
+                        dex: { value: g.attrs?.dex || 0, label: 'DEX', alwaysSubstitute: g.attrs?.dexItalic || false },
+                        str: { value: g.attrs?.str || 0, label: 'STR', alwaysSubstitute: g.attrs?.strItalic || false },
+                        body: { value: g.attrs?.body || 0, label: 'BODY', alwaysSubstitute: g.attrs?.bodyItalic || false },
+                        int: { value: g.attrs?.int || 0, label: 'INT', alwaysSubstitute: false },
+                        will: { value: g.attrs?.will || 0, label: 'WILL', alwaysSubstitute: false },
+                        mind: { value: g.attrs?.mind || 0, label: 'MIND', alwaysSubstitute: false },
+                        infl: { value: g.attrs?.infl || 0, label: 'INFL', alwaysSubstitute: false },
+                        aura: { value: g.attrs?.aura || 0, label: 'AURA', alwaysSubstitute: false },
+                        spirit: { value: g.attrs?.spirit || 0, label: 'SPIRIT', alwaysSubstitute: false },
+                    },
+                    settings: { hasAttributes: g.hasAttributes ?? true },
+                },
+            };
+            const gadgetItem = await actor.createEmbeddedDocuments('Item', [gadgetData]);
+            const gadgetId = gadgetItem[0].id;
+            gadgetIds[g.name] = gadgetId;
+
+            // Create child powers
+            if (g.powers) {
+                for (const p of g.powers) {
+                    const powerData = {
+                        name: p.name,
+                        type: 'power',
+                        system: {
+                            aps: p.aps,
+                            parent: gadgetId,
+                            link: p.link || 'dex',
+                            source: p.source || 'physical',
+                        },
+                    };
+                    const items = await actor.createEmbeddedDocuments('Item', [powerData]);
+                    itemIds[p.name] = items[0].id;
+                }
+            }
+
+            // Create child skills
+            if (g.skills) {
+                for (const s of g.skills) {
+                    const skillData = {
+                        name: s.name,
+                        type: 'skill',
+                        system: {
+                            aps: s.aps,
+                            parent: gadgetId,
+                            link: s.link || 'dex',
+                        },
+                    };
+                    const items = await actor.createEmbeddedDocuments('Item', [skillData]);
+                    itemIds[s.name] = items[0].id;
+                }
+            }
+        }
+
+        return { actorId: actor.id, gadgetIds, itemIds };
+    }, { name, gadgets });
+}
+
+/**
+ * Wait for the Foundry game UI to be fully loaded.
+ */
+async function waitForGameReady(page) {
+    await page.waitForSelector('#sidebar', { timeout: 15000 });
+}
+
+/**
+ * Delete a test actor by ID.
+ */
+async function deleteTestActor(page, actorId) {
+    await page.evaluate(async (id) => {
+        const actor = game.actors.get(id);
+        if (actor) await actor.delete();
+    }, actorId);
+}
+
+/**
+ * Open actor sheet and switch to Gadgets tab.
+ */
+async function openActorGadgetsTab(page, actorId) {
+    await page.evaluate((id) => {
+        const actor = game.actors.get(id);
+        if (!actor) throw new Error('Actor not found: ' + id);
+        actor.sheet.render(true);
+    }, actorId);
+    await page.waitForSelector('.sheet.actor', { timeout: 5000 });
+    await page.click('.sheet.actor .tabs .item[data-tab="gadgets"]');
+    await page.waitForSelector('.sheet.actor .tab.gadgets', { timeout: 5000 });
+}
+
+/**
+ * Close all open windows.
+ */
+async function closeAll(page) {
+    await page.evaluate(() => {
+        Object.values(ui.windows).forEach(w => w.close());
+    });
+    await page.waitForFunction(() => Object.keys(ui.windows).length === 0, { timeout: 5000 });
+}
+
+/**
+ * Get names of gadgets that have a roll button visible.
+ */
+async function getRollableGadgetNames(page) {
+    return page.$$eval(
+        '.sheet.actor .tab.gadgets .item-row',
+        (rows) => rows
+            .filter(row => row.querySelector('.d10.rollable'))
+            .map(row => row.querySelector('.item-name a.item-edit.bold')?.textContent?.trim() || '')
+    );
+}
+
+/**
+ * Get names of gadgets that do NOT have a roll button.
+ */
+async function getNonRollableGadgetNames(page) {
+    return page.$$eval(
+        '.sheet.actor .tab.gadgets .item-row',
+        (rows) => rows
+            .filter(row => !row.querySelector('.d10.rollable'))
+            .map(row => row.querySelector('.item-name a.item-edit.bold')?.textContent?.trim() || '')
+    );
+}
+
+/**
+ * Click the roll button for a specific gadget by name.
+ */
+async function clickGadgetRollButton(page, gadgetName) {
+    const clicked = await page.evaluate((name) => {
+        const rows = document.querySelectorAll('.sheet.actor .tab.gadgets .item-row');
+        for (const row of rows) {
+            const nameEl = row.querySelector('.item-name a.item-edit.bold');
+            if (nameEl && nameEl.textContent.trim() === name) {
+                const btn = row.querySelector('.d10.rollable');
+                if (btn) { btn.click(); return true; }
+                return false;
+            }
+        }
+        return false;
+    }, gadgetName);
+    if (!clicked) throw new Error(`Could not click roll button for "${gadgetName}"`);
+    await page.waitForSelector('.dialog', { timeout: 5000 });
+}
+
+/**
+ * Get the tooltip text of a gadget's roll button.
+ */
+async function getGadgetRollTooltip(page, gadgetName) {
+    return page.evaluate((name) => {
+        const rows = document.querySelectorAll('.sheet.actor .tab.gadgets .item-row');
+        for (const row of rows) {
+            const nameEl = row.querySelector('.item-name a.item-edit.bold');
+            if (nameEl && nameEl.textContent.trim() === name) {
+                const btn = row.querySelector('.d10.rollable');
+                return btn?.getAttribute('title') || null;
+            }
+        }
+        return null;
+    }, gadgetName);
+}
+
+/**
+ * Check if the gadget roll picker dialog is open.
+ */
+async function isPickerDialogOpen(page) {
+    return page.evaluate(() => {
+        for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
+            if (d.querySelector('input[name="selectedOption"]')) return true;
+        }
+        return false;
+    });
+}
+
+/**
+ * Get the option labels from the picker dialog.
+ */
+async function getPickerOptions(page) {
+    return page.$$eval(
+        '.dialog .megs-dialog .gadget-roll-option span',
+        (spans) => spans.map(s => s.textContent.trim())
+    );
+}
+
+/**
+ * Select a picker option by index and click Roll.
+ */
+async function selectPickerOptionAndRoll(page, index) {
+    await page.evaluate((idx) => {
+        const radios = document.querySelectorAll('.dialog .megs-dialog input[name="selectedOption"]');
+        if (radios[idx]) radios[idx].checked = true;
+    }, index);
+    await page.click('.dialog button:has-text("Roll")');
+    await page.waitForSelector('.dialog .megs-dialog #actionValue', { timeout: 5000 });
+}
+
+/**
+ * Cancel/close the picker dialog.
+ */
+async function cancelPickerDialog(page) {
+    await page.evaluate(() => {
+        for (const btn of document.querySelectorAll('.dialog button')) {
+            if (btn.textContent.includes('Close')) { btn.click(); return; }
+        }
+        const x = document.querySelector('.dialog .header-button.close');
+        if (x) x.click();
+    });
+    await page.waitForFunction(
+        () => !document.querySelector('.dialog .megs-dialog input[name="selectedOption"]'),
+        { timeout: 5000 }
+    );
+}
+
+/**
+ * Check if the standard MEGS roll dialog (AV/EV/OV/RV) is open.
+ */
+async function isRollDialogOpen(page) {
+    return page.evaluate(() => {
+        for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
+            if (d.querySelector('#actionValue')) return true;
+        }
+        return false;
+    });
+}
+
+/**
+ * Wait for the roll dialog to appear.
+ */
+async function waitForRollDialog(page) {
+    await page.waitForSelector('.dialog .megs-dialog #actionValue', { timeout: 5000 });
+}
+
+/**
+ * Get AV and EV values from the open roll dialog.
+ */
+async function getRollDialogValues(page) {
+    return page.evaluate(() => {
+        const av = document.querySelector('.dialog .megs-dialog #actionValue');
+        const ev = document.querySelector('.dialog .megs-dialog #effectValue');
+        return {
+            actionValue: av ? Number.parseInt(av.value) : null,
+            effectValue: ev ? Number.parseInt(ev.value) : null,
+        };
+    });
+}
+
+/**
+ * Close the roll dialog via the Close button.
+ */
+async function closeRollDialog(page) {
+    await page.evaluate(() => {
+        for (const btn of document.querySelectorAll('.dialog button')) {
+            if (btn.textContent.includes('Close')) { btn.click(); return; }
+        }
+    });
+    await page.waitForFunction(
+        () => !document.querySelector('.dialog .megs-dialog #actionValue'),
+        { timeout: 5000 }
+    );
+}
+
+/**
+ * Submit the roll dialog via the Roll button and wait for chat message.
+ */
+async function submitRollDialog(page, beforeCount) {
+    await page.evaluate(() => {
+        for (const btn of document.querySelectorAll('.dialog button')) {
+            if (btn.textContent.trim() === 'Roll') { btn.click(); return; }
+        }
+    });
+    await page.waitForFunction(
+        (before) => document.querySelectorAll('#chat-log .chat-message').length > before,
+        { timeout: 10000 },
+        beforeCount
+    );
+}
+
+/**
+ * Count chat messages currently visible.
+ */
+async function getChatMessageCount(page) {
+    return page.evaluate(() => document.querySelectorAll('#chat-log .chat-message').length);
+}
+
+/**
+ * Get the header text of the most recent chat message.
+ */
+async function getLatestChatHeader(page) {
+    return page.evaluate(() => {
+        const msgs = document.querySelectorAll('#chat-log .chat-message');
+        if (!msgs.length) return null;
+        const h = msgs[msgs.length - 1].querySelector('.message-header h4');
+        return h?.textContent?.trim() || null;
+    });
+}
+
+
+// ============================================================
+// TEST SUITE
+// ============================================================
+
+export default function gadgetRollingTests(test, expect) {
+
+    // ----------------------------------------------------------
+    // R1 + R5: Rollability — what should and should not roll
+    // ----------------------------------------------------------
+
+    test('R1: Gadget with explicit AV and EV shows roll button', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R1_AVEV', [
+            { name: 'Blaster', av: 6, ev: 8 },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            const rollable = await getRollableGadgetNames(page);
+            expect(rollable).toContain('Blaster');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R1: Gadget with only EV (no AV) is still rollable', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R1_EVOnly', [
+            { name: 'Baton', av: 0, ev: 7 },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            const rollable = await getRollableGadgetNames(page);
+            expect(rollable).toContain('Baton');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R2: Gadget with only child powers (APs > 0) is rollable', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R2_Powers', [
+            {
+                name: 'Visor',
+                av: 0, ev: 0,
+                powers: [
+                    { name: 'Energy Blast', aps: 10, link: 'dex', source: 'physical' },
+                ],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            const rollable = await getRollableGadgetNames(page);
+            expect(rollable).toContain('Visor');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R5: Gadget with no AV/EV, no powers, no skills, no attributes is NOT rollable', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R5_Empty', [
+            { name: 'Decorative Cape', av: 0, ev: 0 },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            const nonRollable = await getNonRollableGadgetNames(page);
+            expect(nonRollable).toContain('Decorative Cape');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R5/R8: Gadget with only 0-AP skills is NOT rollable', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R5_ZeroSkills', [
+            {
+                name: 'Toolbox',
+                av: 0, ev: 0,
+                skills: [
+                    { name: 'Gadgetry', aps: 0, link: 'int' },
+                    { name: 'Scientist', aps: 0, link: 'int' },
+                ],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            const nonRollable = await getNonRollableGadgetNames(page);
+            expect(nonRollable).toContain('Toolbox');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R5/R8: Gadget with only 0-AP powers is NOT rollable', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R5_ZeroPowers', [
+            {
+                name: 'Dead Battery',
+                av: 0, ev: 0,
+                powers: [
+                    { name: 'Flight', aps: 0, link: 'dex', source: 'physical' },
+                ],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            const nonRollable = await getNonRollableGadgetNames(page);
+            expect(nonRollable).toContain('Dead Battery');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R6: Single option → direct roll dialog, no picker
+    // ----------------------------------------------------------
+
+    test('R6: Single AV/EV option skips picker, opens roll dialog directly', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R6_Single', [
+            { name: 'Pistol', av: 5, ev: 5 },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            await clickGadgetRollButton(page, 'Pistol');
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(false);
+
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            const values = await getRollDialogValues(page);
+            expect(values.actionValue).toBe(5);
+            expect(values.effectValue).toBe(5);
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R6: Single power option skips picker, opens roll dialog directly', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R6_SinglePower', [
+            {
+                name: 'Scope',
+                av: 0, ev: 0,
+                powers: [
+                    { name: 'Telescopic Vision', aps: 8, link: 'int', source: 'mental' },
+                ],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            await clickGadgetRollButton(page, 'Scope');
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(false);
+
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            const values = await getRollDialogValues(page);
+            expect(values.actionValue).toBe(8);
+            expect(values.effectValue).toBe(8);
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R7: Multiple options → picker dialog
+    // ----------------------------------------------------------
+
+    test('R7: Multiple options open picker dialog', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R7_Multi', [
+            {
+                name: 'Trident',
+                av: 0, ev: 12,
+                powers: [
+                    { name: 'Water Control', aps: 10, link: 'int', source: 'mental' },
+                ],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            await clickGadgetRollButton(page, 'Trident');
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(true);
+
+            const options = await getPickerOptions(page);
+            expect(options).toHaveLength(2);
+            expect(options).toContain('Water Control');
+
+            await cancelPickerDialog(page);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R7: Picker shows all powers when gadget has many', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R7_ManyPowers', [
+            {
+                name: 'Power Ring',
+                av: 0, ev: 0,
+                powers: [
+                    { name: 'Flight', aps: 20, link: 'dex', source: 'physical' },
+                    { name: 'Force Field', aps: 15, link: 'will', source: 'mental' },
+                    { name: 'Energy Blast', aps: 18, link: 'dex', source: 'physical' },
+                    { name: 'Comprehend Languages', aps: 12, link: 'int', source: 'mental' },
+                    { name: 'Life Sense', aps: 25, link: 'int', source: 'mental' },
+                ],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            await clickGadgetRollButton(page, 'Power Ring');
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(true);
+
+            const options = await getPickerOptions(page);
+            expect(options).toHaveLength(5);
+            expect(options).toContain('Flight');
+            expect(options).toContain('Force Field');
+            expect(options).toContain('Energy Blast');
+            expect(options).toContain('Comprehend Languages');
+            expect(options).toContain('Life Sense');
+
+            await cancelPickerDialog(page);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R7/R8: Picker excludes 0-AP items, only shows valid options', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R7_Mixed', [
+            {
+                name: 'Utility Belt',
+                av: 0, ev: 6,
+                powers: [
+                    { name: 'Flash', aps: 5, link: 'dex', source: 'physical' },
+                    { name: 'Smoke Screen', aps: 0, link: 'dex', source: 'physical' },
+                ],
+                skills: [
+                    { name: 'Gadgetry', aps: 0, link: 'int' },
+                    { name: 'Thief', aps: 4, link: 'dex' },
+                ],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            await clickGadgetRollButton(page, 'Utility Belt');
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(true);
+
+            const options = await getPickerOptions(page);
+            // Should have: AV/EV, Flash, Thief — NOT Smoke Screen (0 AP) or Gadgetry (0 AP)
+            expect(options).toHaveLength(3);
+            expect(options).toContain('Flash');
+            expect(options).toContain('Thief');
+            expect(options).not.toContain('Smoke Screen');
+            expect(options).not.toContain('Gadgetry');
+
+            await cancelPickerDialog(page);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R7: Canceling picker produces no chat message', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R7_Cancel', [
+            {
+                name: 'Multi-Weapon',
+                av: 3, ev: 5,
+                powers: [{ name: 'Projectile', aps: 7, link: 'dex', source: 'physical' }],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            const beforeCount = await getChatMessageCount(page);
+
+            await clickGadgetRollButton(page, 'Multi-Weapon');
+            expect(await isPickerDialogOpen(page)).toBe(true);
+
+            await cancelPickerDialog(page);
+
+            const afterCount = await getChatMessageCount(page);
+            expect(afterCount).toBe(beforeCount);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R9: Tooltip on roll button
+    // ----------------------------------------------------------
+
+    test('R9: Single-option gadget tooltip shows the one option', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R9_Single', [
+            { name: 'Knife', av: 3, ev: 4 },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            const tooltip = await getGadgetRollTooltip(page, 'Knife');
+            expect(tooltip).not.toBeNull();
+            expect(tooltip.length).toBeGreaterThan(0);
+            // Should contain the gadget name
+            expect(tooltip).toContain('Knife');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R9: Multi-option gadget tooltip lists all options', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R9_Multi', [
+            {
+                name: 'Staff',
+                av: 0, ev: 0,
+                powers: [
+                    { name: 'Lightning', aps: 8, link: 'dex', source: 'physical' },
+                    { name: 'Force Bolt', aps: 6, link: 'will', source: 'mental' },
+                ],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            const tooltip = await getGadgetRollTooltip(page, 'Staff');
+            expect(tooltip).not.toBeNull();
+            expect(tooltip).toContain('Lightning');
+            expect(tooltip).toContain('Force Bolt');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R10: AlwaysSubstitute UI
+    // ----------------------------------------------------------
+
+    test('R10: AlwaysSubstitute checkbox visible in gadget edit mode', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R10_Italic', [
+            { name: 'Power Suit', av: 0, ev: 0, attrs: { dex: 8, str: 10 } },
+        ]);
+        try {
+            // Open the gadget's own item sheet
+            await page.evaluate((info) => {
+                const actor = game.actors.get(info.actorId);
+                const gadget = actor.items.get(info.gadgetId);
+                gadget.sheet.render(true);
+            }, { actorId: data.actorId, gadgetId: data.gadgetIds['Power Suit'] });
+
+            await page.waitForSelector('.sheet.item .always-substitute-label input[type="checkbox"]', { timeout: 5000 });
+
+            // Verify checkboxes exist for always-substitute
+            const checkboxCount = await page.$$eval(
+                '.sheet.item .always-substitute-label input[type="checkbox"]',
+                (cbs) => cbs.length
+            );
+            expect(checkboxCount).toBeGreaterThan(0);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R10: Toggling AlwaysSubstitute persists after closing and reopening sheet', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R10_Persist', [
+            { name: 'Armor', av: 0, ev: 0, attrs: { dex: 8, str: 10 } },
+        ]);
+        try {
+            // Open the gadget sheet
+            await page.evaluate((info) => {
+                const actor = game.actors.get(info.actorId);
+                const gadget = actor.items.get(info.gadgetId);
+                gadget.sheet.render(true);
+            }, { actorId: data.actorId, gadgetId: data.gadgetIds['Armor'] });
+
+            await page.waitForSelector('.sheet.item .always-substitute-label input[type="checkbox"]', { timeout: 5000 });
+
+            // Verify DEX checkbox starts unchecked
+            const initialState = await page.$$eval(
+                '.sheet.item .always-substitute-label input[type="checkbox"]',
+                (cbs) => cbs.map(cb => cb.checked)
+            );
+            expect(initialState[0]).toBe(false);
+
+            // Click the DEX always-substitute checkbox and wait for Foundry to persist
+            await page.evaluate(() => {
+                const cbs = document.querySelectorAll('.sheet.item .always-substitute-label input[type="checkbox"]');
+                if (cbs[0]) cbs[0].click();
+            });
+            await page.waitForFunction((info) => {
+                const actor = game.actors.get(info.actorId);
+                const gadget = actor?.items.get(info.gadgetId);
+                return gadget?.system?.attributes?.dex?.alwaysSubstitute === true;
+            }, { timeout: 5000 }, { actorId: data.actorId, gadgetId: data.gadgetIds['Armor'] });
+
+            // Close all sheets
+            await closeAll(page);
+
+            // Verify data model persisted
+            const persisted = await page.evaluate((info) => {
+                const actor = game.actors.get(info.actorId);
+                const gadget = actor.items.get(info.gadgetId);
+                return gadget.system.attributes.dex.alwaysSubstitute;
+            }, { actorId: data.actorId, gadgetId: data.gadgetIds['Armor'] });
+            expect(persisted).toBe(true);
+
+            // Reopen the gadget sheet
+            await page.evaluate((info) => {
+                const actor = game.actors.get(info.actorId);
+                const gadget = actor.items.get(info.gadgetId);
+                gadget.sheet.render(true);
+            }, { actorId: data.actorId, gadgetId: data.gadgetIds['Armor'] });
+
+            await page.waitForSelector('.sheet.item .always-substitute-label input[type="checkbox"]', { timeout: 5000 });
+
+            // Verify the checkbox is still checked in the UI
+            const afterReopen = await page.$$eval(
+                '.sheet.item .always-substitute-label input[type="checkbox"]',
+                (cbs) => cbs.map(cb => cb.checked)
+            );
+            expect(afterReopen[0]).toBe(true);
+            // STR should still be unchecked
+            expect(afterReopen[1]).toBe(false);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R11: Macro support (item.roll())
+    // ----------------------------------------------------------
+
+    test('R11: item.roll() on single-option gadget triggers roll flow', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R11_Macro', [
+            { name: 'Sidearm', av: 4, ev: 6 },
+        ]);
+        try {
+            const beforeCount = await getChatMessageCount(page);
+
+            await page.evaluate((info) => {
+                const actor = game.actors.get(info.actorId);
+                const gadget = actor.items.get(info.gadgetId);
+                gadget.roll();
+            }, { actorId: data.actorId, gadgetId: data.gadgetIds['Sidearm'] });
+
+            await waitForRollDialog(page);
+
+            // Should open the roll dialog (single option, no picker)
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            await submitRollDialog(page, beforeCount);
+
+            const afterCount = await getChatMessageCount(page);
+            expect(afterCount).toBeGreaterThan(beforeCount);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R11: item.roll() on multi-option gadget shows picker', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R11_MacroPicker', [
+            {
+                name: 'Combo Weapon',
+                av: 3, ev: 5,
+                powers: [{ name: 'Flame Proj', aps: 7, link: 'dex', source: 'physical' }],
+            },
+        ]);
+        try {
+            await page.evaluate((info) => {
+                const actor = game.actors.get(info.actorId);
+                const gadget = actor.items.get(info.gadgetId);
+                gadget.roll();
+            }, { actorId: data.actorId, gadgetId: data.gadgetIds['Combo Weapon'] });
+
+            await page.waitForSelector('.dialog', { timeout: 5000 });
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(true);
+
+            await cancelPickerDialog(page);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('R11: item.roll() on non-rollable gadget posts description to chat', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R11_NoRoll', [
+            { name: 'Trophy', av: 0, ev: 0, description: 'A decorative trophy.' },
+        ]);
+        try {
+            const beforeCount = await getChatMessageCount(page);
+
+            await page.evaluate((info) => {
+                const actor = game.actors.get(info.actorId);
+                const gadget = actor.items.get(info.gadgetId);
+                gadget.roll();
+            }, { actorId: data.actorId, gadgetId: data.gadgetIds['Trophy'] });
+
+            // Wait for chat message to appear
+            await page.waitForFunction(
+                (before) => document.querySelectorAll('#chat-log .chat-message').length > before,
+                { timeout: 5000 },
+                beforeCount
+            );
+
+            // No picker, no roll dialog
+            expect(await isPickerDialogOpen(page)).toBe(false);
+            expect(await isRollDialogOpen(page)).toBe(false);
+
+            // But a chat message should have been posted (description)
+            const afterCount = await getChatMessageCount(page);
+            expect(afterCount).toBeGreaterThan(beforeCount);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R12: Chat message labels
+    // ----------------------------------------------------------
+
+    test('R12: Chat message from gadget roll includes gadget name', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const actorName = TEST_ACTOR_PREFIX + 'R12_Label';
+        const data = await createTestActor(page, actorName, [
+            { name: 'Laser Rifle', av: 7, ev: 9 },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            const beforeCount = await getChatMessageCount(page);
+            await clickGadgetRollButton(page, 'Laser Rifle');
+
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            await submitRollDialog(page, beforeCount);
+
+            const header = await getLatestChatHeader(page);
+            expect(header).not.toBeNull();
+            // Header should mention the gadget name
+            expect(header).toContain('Laser Rifle');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // Edge cases
+    // ----------------------------------------------------------
+
+    test('EDGE: Gadget with EV but 0 AV derives AV and still rolls correctly', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'EDGE_ZeroAV', [
+            { name: 'Club', av: 0, ev: 9 },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+            await clickGadgetRollButton(page, 'Club');
+
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            const values = await getRollDialogValues(page);
+            expect(values.effectValue).toBe(9);
+            // AV should be derived (not left at 0) — exact value depends on actor/gadget
+            // At minimum it should be populated
+            expect(values.actionValue).not.toBeNull();
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('EDGE: Actor with multiple gadgets shows correct rollability for each', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'EDGE_MultiGadget', [
+            { name: 'Weapon A', av: 5, ev: 8 },
+            { name: 'Ornament', av: 0, ev: 0 },
+            {
+                name: 'Scanner',
+                av: 0, ev: 0,
+                powers: [{ name: 'Detect', aps: 6, link: 'int', source: 'mental' }],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+
+            const rollable = await getRollableGadgetNames(page);
+            const nonRollable = await getNonRollableGadgetNames(page);
+
+            expect(rollable).toContain('Weapon A');
+            expect(rollable).toContain('Scanner');
+            expect(nonRollable).toContain('Ornament');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    test('EDGE: Selecting different picker options produces correct AV/EV', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'EDGE_PickerVals', [
+            {
+                name: 'Versatile Weapon',
+                av: 4, ev: 6,
+                powers: [{ name: 'Flame Jet', aps: 10, link: 'dex', source: 'physical' }],
+            },
+        ]);
+        try {
+            await openActorGadgetsTab(page, data.actorId);
+
+            // First: select the power option (index 1 — powers come after AV/EV)
+            await clickGadgetRollButton(page, 'Versatile Weapon');
+            expect(await isPickerDialogOpen(page)).toBe(true);
+
+            const options = await getPickerOptions(page);
+            expect(options).toHaveLength(2);
+
+            // Select the power (second option)
+            await selectPickerOptionAndRoll(page, 1);
+
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            const powerValues = await getRollDialogValues(page);
+            // Power AV=EV=APs=10
+            expect(powerValues.actionValue).toBe(10);
+            expect(powerValues.effectValue).toBe(10);
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+}

--- a/e2e/legacy/gadget-sheet-rolling.spec.mjs
+++ b/e2e/legacy/gadget-sheet-rolling.spec.mjs
@@ -1,0 +1,543 @@
+/**
+ * E2E tests for Issue #13: Roll attacks from gadget sheet
+ *
+ * These tests verify that a gadget's item sheet has a roll button that
+ * triggers the full gadget roll flow (picker dialog when multiple options,
+ * direct roll dialog when single option).
+ *
+ * Requirements under test:
+ * R1. A gadget sheet with explicit AV/EV shows a roll button in the header.
+ * R2. A gadget sheet with child powers shows a roll button.
+ * R3. A gadget sheet with attribute pairs shows a roll button.
+ * R4. A gadget sheet with NO rollable options does NOT show a roll button.
+ * R5. Single roll option: clicking roll button opens roll dialog directly.
+ * R6. Multiple roll options: clicking roll button opens picker dialog.
+ * R7. Roll button tooltip indicates available roll options.
+ * R8. Roll from gadget sheet produces a chat message identifying the gadget.
+ * R9. Picker dialog from gadget sheet lists all available options.
+ *
+ * Preconditions:
+ * - Foundry VTT running at http://localhost:30000 with a MEGS world loaded
+ * - Logged in as Gamemaster
+ */
+
+const FOUNDRY_URL = 'http://localhost:30000/game';
+const TEST_ACTOR_PREFIX = '_E2E_GadgetSheetRoll_';
+
+// ============================================================
+// Foundry API Helpers
+// ============================================================
+
+async function createTestActor(page, name, gadgets) {
+    return page.evaluate(async ({ name, gadgets }) => {
+        const actor = await Actor.create({
+            name,
+            type: 'hero',
+            system: {
+                attributes: {
+                    dex: { value: 5 },
+                    str: { value: 4 },
+                    body: { value: 4 },
+                    int: { value: 3 },
+                    will: { value: 3 },
+                    mind: { value: 3 },
+                    infl: { value: 3 },
+                    aura: { value: 3 },
+                    spirit: { value: 3 },
+                },
+                heroPoints: { value: 10 },
+            },
+        });
+
+        const gadgetIds = {};
+        const itemIds = {};
+
+        for (const g of gadgets) {
+            const gadgetData = {
+                name: g.name,
+                type: 'gadget',
+                system: {
+                    actionValue: g.av || 0,
+                    effectValue: g.ev || 0,
+                    description: g.description || '',
+                    settings: {
+                        hasAVAndEV: (g.av > 0 || g.ev > 0) ? 'true' : 'false',
+                        hasAttributes: g.hasAttributes ?? {
+                            physical: 'true',
+                            mental: 'false',
+                            mystical: 'false',
+                        },
+                        hasPowers: (g.powers && g.powers.length > 0) ? 'true' : 'false',
+                        hasSkills: (g.skills && g.skills.length > 0) ? 'true' : 'false',
+                        hasGadgets: 'false',
+                        hasTraits: 'false',
+                    },
+                    attributes: {
+                        dex: { value: g.attrs?.dex || 0, label: 'DEX', alwaysSubstitute: false },
+                        str: { value: g.attrs?.str || 0, label: 'STR', alwaysSubstitute: false },
+                        body: { value: g.attrs?.body || 0, label: 'BODY', alwaysSubstitute: false },
+                        int: { value: g.attrs?.int || 0, label: 'INT', alwaysSubstitute: false },
+                        will: { value: g.attrs?.will || 0, label: 'WILL', alwaysSubstitute: false },
+                        mind: { value: g.attrs?.mind || 0, label: 'MIND', alwaysSubstitute: false },
+                        infl: { value: g.attrs?.infl || 0, label: 'INFL', alwaysSubstitute: false },
+                        aura: { value: g.attrs?.aura || 0, label: 'AURA', alwaysSubstitute: false },
+                        spirit: { value: g.attrs?.spirit || 0, label: 'SPIRIT', alwaysSubstitute: false },
+                    },
+                },
+            };
+            const gadgetItem = await actor.createEmbeddedDocuments('Item', [gadgetData]);
+            const gadgetId = gadgetItem[0].id;
+            gadgetIds[g.name] = gadgetId;
+
+            if (g.powers) {
+                for (const p of g.powers) {
+                    const powerData = {
+                        name: p.name,
+                        type: 'power',
+                        system: {
+                            aps: p.aps,
+                            parent: gadgetId,
+                            link: p.link || 'dex',
+                            source: p.source || 'physical',
+                        },
+                    };
+                    const items = await actor.createEmbeddedDocuments('Item', [powerData]);
+                    itemIds[p.name] = items[0].id;
+                }
+            }
+
+            if (g.skills) {
+                for (const s of g.skills) {
+                    const skillData = {
+                        name: s.name,
+                        type: 'skill',
+                        system: {
+                            aps: s.aps,
+                            parent: gadgetId,
+                            link: s.link || 'dex',
+                        },
+                    };
+                    const items = await actor.createEmbeddedDocuments('Item', [skillData]);
+                    itemIds[s.name] = items[0].id;
+                }
+            }
+        }
+
+        return { actorId: actor.id, gadgetIds, itemIds };
+    }, { name, gadgets });
+}
+
+async function waitForGameReady(page) {
+    await page.waitForSelector('#sidebar', { timeout: 15000 });
+}
+
+async function deleteTestActor(page, actorId) {
+    await page.evaluate(async (id) => {
+        const actor = game.actors.get(id);
+        if (actor) await actor.delete();
+    }, actorId);
+}
+
+async function closeAll(page) {
+    await page.evaluate(() => {
+        Object.values(ui.windows).forEach(w => w.close());
+    });
+    await page.waitForFunction(() => Object.keys(ui.windows).length === 0, { timeout: 5000 });
+}
+
+/**
+ * Open a gadget's item sheet by its ID on an actor.
+ */
+async function openGadgetSheet(page, actorId, gadgetId) {
+    await page.evaluate(({ actorId, gadgetId }) => {
+        const actor = game.actors.get(actorId);
+        if (!actor) throw new Error('Actor not found: ' + actorId);
+        const gadget = actor.items.get(gadgetId);
+        if (!gadget) throw new Error('Gadget not found: ' + gadgetId);
+        gadget.sheet.render(true);
+    }, { actorId, gadgetId });
+    await page.waitForSelector('.sheet.item', { timeout: 5000 });
+}
+
+/**
+ * Check if the gadget sheet roll button is visible.
+ */
+async function hasGadgetSheetRollButton(page) {
+    return page.evaluate(() => {
+        const btn = document.querySelector('.sheet.item .d10.rollable[data-type="gadget-roll"]');
+        return !!btn;
+    });
+}
+
+/**
+ * Get the tooltip of the gadget sheet roll button.
+ */
+async function getGadgetSheetRollTooltip(page) {
+    return page.evaluate(() => {
+        const btn = document.querySelector('.sheet.item .d10.rollable[data-type="gadget-roll"]');
+        return btn?.getAttribute('title') || null;
+    });
+}
+
+/**
+ * Click the gadget sheet roll button.
+ */
+async function clickGadgetSheetRollButton(page) {
+    const clicked = await page.evaluate(() => {
+        const btn = document.querySelector('.sheet.item .d10.rollable[data-type="gadget-roll"]');
+        if (btn) { btn.click(); return true; }
+        return false;
+    });
+    if (!clicked) throw new Error('Gadget sheet roll button not found');
+}
+
+/**
+ * Check if the roll dialog (AV/EV/OV/RV) is open.
+ */
+async function isRollDialogOpen(page) {
+    return page.evaluate(() => {
+        for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
+            if (d.querySelector('#actionValue')) return true;
+        }
+        return false;
+    });
+}
+
+/**
+ * Wait for the roll dialog to appear.
+ */
+async function waitForRollDialog(page) {
+    await page.waitForSelector('.dialog .megs-dialog #actionValue', { timeout: 5000 });
+}
+
+/**
+ * Get AV and EV values from the open roll dialog.
+ */
+async function getRollDialogValues(page) {
+    return page.evaluate(() => {
+        const av = document.querySelector('.dialog .megs-dialog #actionValue');
+        const ev = document.querySelector('.dialog .megs-dialog #effectValue');
+        return {
+            actionValue: av ? Number.parseInt(av.value) : null,
+            effectValue: ev ? Number.parseInt(ev.value) : null,
+        };
+    });
+}
+
+/**
+ * Check if the picker dialog is open.
+ */
+async function isPickerDialogOpen(page) {
+    return page.evaluate(() => {
+        for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
+            if (d.querySelector('input[name="selectedOption"]')) return true;
+        }
+        return false;
+    });
+}
+
+/**
+ * Get the option labels from the picker dialog.
+ */
+async function getPickerOptions(page) {
+    return page.$$eval(
+        '.dialog .megs-dialog .gadget-roll-option span',
+        (spans) => spans.map(s => s.textContent.trim())
+    );
+}
+
+/**
+ * Close the roll dialog via the Close button.
+ */
+async function closeRollDialog(page) {
+    await page.evaluate(() => {
+        for (const btn of document.querySelectorAll('.dialog button')) {
+            if (btn.textContent.trim() === 'Close') { btn.click(); return; }
+        }
+    });
+    await page.waitForFunction(
+        () => !document.querySelector('.dialog .megs-dialog #actionValue'),
+        { timeout: 5000 }
+    );
+}
+
+/**
+ * Submit the roll dialog via the Submit button and wait for chat message.
+ */
+async function submitRollDialog(page, beforeCount) {
+    await page.evaluate(() => {
+        for (const btn of document.querySelectorAll('.dialog button')) {
+            if (btn.textContent.trim() === 'Submit') { btn.click(); return; }
+        }
+    });
+    await page.waitForFunction(
+        (before) => document.querySelectorAll('#chat-log .chat-message').length > before,
+        { timeout: 10000 },
+        beforeCount
+    );
+}
+
+async function getChatMessageCount(page) {
+    return page.evaluate(() => document.querySelectorAll('#chat-log .chat-message').length);
+}
+
+async function getLatestChatHeader(page) {
+    return page.evaluate(() => {
+        const msgs = document.querySelectorAll('#chat-log .chat-message');
+        if (!msgs.length) return null;
+        const h = msgs[msgs.length - 1].querySelector('.message-header h4');
+        return h?.textContent?.trim() || null;
+    });
+}
+
+
+// ============================================================
+// TEST SUITE
+// ============================================================
+
+export default function gadgetSheetRollingTests(test, expect) {
+
+    // ----------------------------------------------------------
+    // R1: Roll button on gadget sheet with AV/EV
+    // ----------------------------------------------------------
+    test('R1: Gadget sheet with AV/EV shows roll button', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R1', [
+            { name: 'TestWeapon', av: 6, ev: 8 },
+        ]);
+        try {
+            await openGadgetSheet(page, data.actorId, data.gadgetIds['TestWeapon']);
+            const hasBtn = await hasGadgetSheetRollButton(page);
+            expect(hasBtn).toBe(true);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R2: Roll button on gadget sheet with child powers
+    // ----------------------------------------------------------
+    test('R2: Gadget sheet with child power shows roll button', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R2', [
+            {
+                name: 'TestDevice',
+                powers: [{ name: 'EnergyBlast', aps: 8, link: 'dex', source: 'physical' }],
+            },
+        ]);
+        try {
+            await openGadgetSheet(page, data.actorId, data.gadgetIds['TestDevice']);
+            const hasBtn = await hasGadgetSheetRollButton(page);
+            expect(hasBtn).toBe(true);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R3: Roll button on gadget sheet with attributes
+    // ----------------------------------------------------------
+    test('R3: Gadget sheet with DEX/STR attributes shows roll button', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R3', [
+            {
+                name: 'TestSuit',
+                attrs: { dex: 7, str: 9 },
+                hasAttributes: { physical: 'true', mental: 'false', mystical: 'false' },
+            },
+        ]);
+        try {
+            await openGadgetSheet(page, data.actorId, data.gadgetIds['TestSuit']);
+            const hasBtn = await hasGadgetSheetRollButton(page);
+            expect(hasBtn).toBe(true);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R4: No roll button when no rollable options
+    // ----------------------------------------------------------
+    test('R4: Gadget sheet with no rollable options hides roll button', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R4', [
+            {
+                name: 'TestContainer',
+                attrs: { body: 5 },
+                hasAttributes: { physical: 'true', mental: 'false', mystical: 'false' },
+            },
+        ]);
+        try {
+            await openGadgetSheet(page, data.actorId, data.gadgetIds['TestContainer']);
+            const hasBtn = await hasGadgetSheetRollButton(page);
+            expect(hasBtn).toBe(false);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R5: Single option goes directly to roll dialog
+    // ----------------------------------------------------------
+    test('R5: Single roll option opens roll dialog directly', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R5', [
+            { name: 'TestGun', av: 4, ev: 7 },
+        ]);
+        try {
+            await openGadgetSheet(page, data.actorId, data.gadgetIds['TestGun']);
+            await clickGadgetSheetRollButton(page);
+            await waitForRollDialog(page);
+
+            const isRoll = await isRollDialogOpen(page);
+            expect(isRoll).toBe(true);
+
+            const values = await getRollDialogValues(page);
+            expect(values.actionValue).toBe(4);
+            expect(values.effectValue).toBe(7);
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R6: Multiple options open picker dialog
+    // ----------------------------------------------------------
+    test('R6: Multiple roll options opens picker dialog', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R6', [
+            {
+                name: 'TestMulti',
+                av: 5, ev: 5,
+                powers: [{ name: 'HeatVision', aps: 10, link: 'dex', source: 'physical' }],
+            },
+        ]);
+        try {
+            await openGadgetSheet(page, data.actorId, data.gadgetIds['TestMulti']);
+            await clickGadgetSheetRollButton(page);
+
+            await page.waitForFunction(() => {
+                for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
+                    if (d.querySelector('input[name="selectedOption"]')) return true;
+                }
+                return false;
+            }, { timeout: 5000 });
+
+            const isPicker = await isPickerDialogOpen(page);
+            expect(isPicker).toBe(true);
+
+            const options = await getPickerOptions(page);
+            expect(options.length).toBeGreaterThanOrEqual(2);
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R7: Roll button tooltip shows option info
+    // ----------------------------------------------------------
+    test('R7: Roll button tooltip indicates rollable options', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R7', [
+            { name: 'TestBlaster', av: 6, ev: 8 },
+        ]);
+        try {
+            await openGadgetSheet(page, data.actorId, data.gadgetIds['TestBlaster']);
+            const tooltip = await getGadgetSheetRollTooltip(page);
+            expect(tooltip).not.toBeNull();
+            expect(tooltip).toContain('TestBlaster');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R8: Roll from gadget sheet produces chat message
+    // ----------------------------------------------------------
+    test('R8: Rolling from gadget sheet produces chat message with gadget name', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R8', [
+            { name: 'TestRifle', av: 5, ev: 6 },
+        ]);
+        try {
+            await openGadgetSheet(page, data.actorId, data.gadgetIds['TestRifle']);
+            const beforeCount = await getChatMessageCount(page);
+
+            await clickGadgetSheetRollButton(page);
+            await waitForRollDialog(page);
+            await submitRollDialog(page, beforeCount);
+
+            const header = await getLatestChatHeader(page);
+            expect(header).not.toBeNull();
+            expect(header).toContain('TestRifle');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R9: Picker options match available gadget abilities
+    // ----------------------------------------------------------
+    test('R9: Picker dialog lists all rollable options from gadget', async ({ page }) => {
+        await page.goto(FOUNDRY_URL);
+        await waitForGameReady(page);
+
+        const data = await createTestActor(page, TEST_ACTOR_PREFIX + 'R9', [
+            {
+                name: 'TestMultiAbility',
+                av: 3, ev: 3,
+                attrs: { dex: 6, str: 8 },
+                hasAttributes: { physical: 'true', mental: 'false', mystical: 'false' },
+                powers: [{ name: 'Flame', aps: 7, link: 'dex', source: 'physical' }],
+            },
+        ]);
+        try {
+            await openGadgetSheet(page, data.actorId, data.gadgetIds['TestMultiAbility']);
+            await clickGadgetSheetRollButton(page);
+
+            await page.waitForFunction(() => {
+                for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
+                    if (d.querySelector('input[name="selectedOption"]')) return true;
+                }
+                return false;
+            }, { timeout: 5000 });
+
+            const options = await getPickerOptions(page);
+            const optionTexts = options.join(' ');
+
+            // Should have AV/EV option, power option, and attribute pair option
+            expect(options.length).toBeGreaterThanOrEqual(3);
+            expect(optionTexts).toContain('Flame');
+            expect(optionTexts).toContain('DEX/STR');
+        } finally {
+            await closeAll(page);
+            await deleteTestActor(page, data.actorId);
+        }
+    });
+}

--- a/e2e/tests/accordion-state.spec.mjs
+++ b/e2e/tests/accordion-state.spec.mjs
@@ -1,0 +1,200 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    addSkillToActor,
+    addPowerToActor,
+    deleteActor,
+    openActorSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+test.describe('Accordion State Persistence (#67)', () => {
+    test('Expanded skill row stays expanded after re-render', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Accordion_Expand'));
+            await addSkillToActor(page, actorId, {
+                name: 'Acrobatics',
+                aps: 4,
+                link: 'dex',
+            });
+
+            await openActorSheet(page, actorId, 'skills');
+
+            // Find the skill row and click the toggle icon to expand it
+            await page.evaluate((actorId) => {
+                const sheet = document.querySelector('.sheet.actor');
+                const skillRows = sheet.querySelectorAll('.tab.skills .skill-row');
+                for (const row of skillRows) {
+                    const icon = row.querySelector('.toggle-icon');
+                    if (icon) {
+                        icon.click();
+                        break;
+                    }
+                }
+            }, actorId);
+
+            // Wait a moment for the toggle animation
+            await page.waitForTimeout(300);
+
+            // Verify it is expanded (icon should be chevron-down)
+            const expandedBefore = await page.evaluate(() => {
+                const row = document.querySelector('.sheet.actor .tab.skills .skill-row');
+                const icon = row?.querySelector('.toggle-icon');
+                return icon?.classList.contains('fa-chevron-down') || false;
+            });
+            expect(expandedBefore).toBe(true);
+
+            // Trigger a re-render via the actor sheet
+            await page.evaluate((actorId) => {
+                const actor = game.actors.get(actorId);
+                actor.sheet.render(true);
+            }, actorId);
+
+            // Wait for the sheet to re-render
+            await page.waitForSelector('.sheet.actor .tab.skills .skill-row', { timeout: 5000 });
+            await page.waitForTimeout(300);
+
+            // Verify the expanded state was restored
+            const expandedAfter = await page.evaluate(() => {
+                const row = document.querySelector('.sheet.actor .tab.skills .skill-row');
+                const icon = row?.querySelector('.toggle-icon');
+                return icon?.classList.contains('fa-chevron-down') || false;
+            });
+            expect(expandedAfter).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Collapsed skill row stays collapsed after re-render', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Accordion_Collapse'));
+            await addSkillToActor(page, actorId, {
+                name: 'Detective',
+                aps: 5,
+                link: 'int',
+            });
+
+            await openActorSheet(page, actorId, 'skills');
+
+            // The default state is collapsed (data-expanded='false', fa-chevron-right)
+            // Verify it starts collapsed
+            const collapsedBefore = await page.evaluate(() => {
+                const row = document.querySelector('.sheet.actor .tab.skills .skill-row');
+                const icon = row?.querySelector('.toggle-icon');
+                return icon?.classList.contains('fa-chevron-right') || false;
+            });
+            expect(collapsedBefore).toBe(true);
+
+            // Trigger re-render
+            await page.evaluate((actorId) => {
+                const actor = game.actors.get(actorId);
+                actor.sheet.render(true);
+            }, actorId);
+
+            await page.waitForSelector('.sheet.actor .tab.skills .skill-row', { timeout: 5000 });
+            await page.waitForTimeout(300);
+
+            // Verify it remains collapsed after re-render
+            const collapsedAfter = await page.evaluate(() => {
+                const row = document.querySelector('.sheet.actor .tab.skills .skill-row');
+                const icon = row?.querySelector('.toggle-icon');
+                return icon?.classList.contains('fa-chevron-right') || false;
+            });
+            expect(collapsedAfter).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Mixed accordion states survive re-render independently', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Accordion_Mixed'));
+            const skillId1 = await addSkillToActor(page, actorId, {
+                name: 'Acrobatics',
+                aps: 4,
+                link: 'dex',
+            });
+            const skillId2 = await addSkillToActor(page, actorId, {
+                name: 'Thief',
+                aps: 3,
+                link: 'dex',
+            });
+
+            await openActorSheet(page, actorId, 'skills');
+
+            // Expand only the first skill row (Acrobatics comes first alphabetically)
+            await page.evaluate((id1) => {
+                const sheet = document.querySelector('.sheet.actor');
+                const rows = sheet.querySelectorAll('.tab.skills .skill-row');
+                for (const row of rows) {
+                    if (row.dataset.itemId === id1) {
+                        const icon = row.querySelector('.toggle-icon');
+                        if (icon) icon.click();
+                        break;
+                    }
+                }
+            }, skillId1);
+
+            await page.waitForTimeout(300);
+
+            // Verify: first expanded, second collapsed
+            const statesBefore = await page.evaluate(({ id1, id2 }) => {
+                const sheet = document.querySelector('.sheet.actor');
+                const rows = sheet.querySelectorAll('.tab.skills .skill-row');
+                const result = {};
+                for (const row of rows) {
+                    const icon = row.querySelector('.toggle-icon');
+                    if (row.dataset.itemId === id1) {
+                        result.first = icon?.classList.contains('fa-chevron-down') || false;
+                    }
+                    if (row.dataset.itemId === id2) {
+                        result.second = icon?.classList.contains('fa-chevron-right') || false;
+                    }
+                }
+                return result;
+            }, { id1: skillId1, id2: skillId2 });
+
+            expect(statesBefore.first).toBe(true);
+            expect(statesBefore.second).toBe(true);
+
+            // Trigger re-render
+            await page.evaluate((actorId) => {
+                const actor = game.actors.get(actorId);
+                actor.sheet.render(true);
+            }, actorId);
+
+            await page.waitForSelector('.sheet.actor .tab.skills .skill-row', { timeout: 5000 });
+            await page.waitForTimeout(300);
+
+            // Verify: first still expanded, second still collapsed
+            const statesAfter = await page.evaluate(({ id1, id2 }) => {
+                const sheet = document.querySelector('.sheet.actor');
+                const rows = sheet.querySelectorAll('.tab.skills .skill-row');
+                const result = {};
+                for (const row of rows) {
+                    const icon = row.querySelector('.toggle-icon');
+                    if (row.dataset.itemId === id1) {
+                        result.first = icon?.classList.contains('fa-chevron-down') || false;
+                    }
+                    if (row.dataset.itemId === id2) {
+                        result.second = icon?.classList.contains('fa-chevron-right') || false;
+                    }
+                }
+                return result;
+            }, { id1: skillId1, id2: skillId2 });
+
+            expect(statesAfter.first).toBe(true);
+            expect(statesAfter.second).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/accordion-state.spec.mjs
+++ b/e2e/tests/accordion-state.spec.mjs
@@ -11,6 +11,9 @@ import {
 
 test.describe('Accordion State Persistence (#67)', () => {
     test('Expanded skill row stays expanded after re-render', async ({ page }) => {
+        // KNOWN BUG #242: accordion state is lost on re-renders that don't go
+        // through the instrumented handlers. Remove this once #242 is fixed.
+        test.fail();
         let actorId;
         try {
             actorId = await createHeroActor(page, prefixName('Accordion_Expand'));
@@ -113,6 +116,9 @@ test.describe('Accordion State Persistence (#67)', () => {
     });
 
     test('Mixed accordion states survive re-render independently', async ({ page }) => {
+        // KNOWN BUG #242: accordion state is lost on re-renders that don't go
+        // through the instrumented handlers. Remove this once #242 is fixed.
+        test.fail();
         let actorId;
         try {
             actorId = await createHeroActor(page, prefixName('Accordion_Mixed'));

--- a/e2e/tests/action-resolution.spec.mjs
+++ b/e2e/tests/action-resolution.spec.mjs
@@ -1,0 +1,320 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    deleteActor,
+    openActorSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+import {
+    waitForRollDialog,
+    getRollDialogValues,
+    fillRollDialog,
+    clickRollDialogSubmit,
+    submitRollDialog,
+    answerDoublesPrompt,
+    queueDice,
+    restoreDice,
+    getChatMessageCount,
+    parseLatestRollMessage,
+} from '../fixtures/roll-helpers.mjs';
+
+/**
+ * Category 6 of #226: Dice Rolling — Action Resolution (3E Rules Ch. 2).
+ *
+ * Expected values are hardcoded from assets/data/tables.json:
+ *   ranges:            [0,0],[1,2],[3,4],[5,6],[7,8],[9,10],...
+ *   actionTable[3]  (AV 5-6):  [4, 7, 9, 11, 13, 15, 18, 21]
+ *   resultTable[3]  (EV 5-6):  [A,  3, 2, 1, 0, ...]
+ *
+ * Dice are made deterministic by overriding Die.prototype.randomFace
+ * (see queueDice in roll-helpers.mjs).
+ */
+test.describe('Action Resolution (#226 cat 6)', () => {
+    /** Create hero (dex 5 / str 4 defaults), open its sheet, click the DEX roll label. */
+    async function openDexRollDialog(page, actorId) {
+        await page.evaluate(() => {
+            for (const t of [...game.user.targets]) {
+                t.setTarget(false, { user: game.user, releaseOthers: false });
+            }
+        });
+        await openActorSheet(page, actorId, 'abilities');
+        await page.click('.sheet.actor .tab.abilities .resource-label.rollable[data-key="dex"]');
+        await waitForRollDialog(page);
+    }
+
+    test('Clicking a rollable attribute opens the roll dialog with AV/EV/OV/RV fields', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_DialogFields'));
+            await openDexRollDialog(page, actorId);
+
+            // AV = DEX (5); EV = paired STR (4); OV/RV empty with no target
+            const values = await getRollDialogValues(page);
+            expect(values.actionValue).toBe(5);
+            expect(values.effectValue).toBe(4);
+
+            const hasOvRv = await page.evaluate(() => {
+                const d = document.querySelector('.dialog .megs-dialog');
+                return !!(d.querySelector('#opposingValue') && d.querySelector('#resistanceValue'));
+            });
+            expect(hasOvRv).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Action Table: AV 5 vs OV 5 produces difficulty 11; EV 5 vs RV 3 gives 2 RAPs', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_Difficulty'));
+            await openDexRollDialog(page, actorId);
+            await fillRollDialog(page, { av: 5, ev: 5, ov: 5, rv: 3 });
+
+            await queueDice(page, [6, 5]); // total 11, exactly meets difficulty
+            const before = await getChatMessageCount(page);
+            await submitRollDialog(page, before);
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.difficulty).toBe(11);
+            expect(msg.rollTotal).toBe(11);
+            expect(msg.dice).toEqual([6, 5]);
+            expect(msg.isSuccess).toBe(true);
+            expect(msg.resultText).toContain('Success: 2 RAPs!');
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Roll below difficulty fails with failure styling', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_Failure'));
+            await openDexRollDialog(page, actorId);
+            await fillRollDialog(page, { av: 5, ev: 5, ov: 5, rv: 5 });
+
+            await queueDice(page, [3, 4]); // total 7 < difficulty 11
+            const before = await getChatMessageCount(page);
+            await submitRollDialog(page, before);
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.difficulty).toBe(11);
+            expect(msg.rollTotal).toBe(7);
+            expect(msg.resultText).toContain('Action failed!');
+            expect(msg.isFailure).toBe(true);
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Double 1s is automatic failure regardless of AV/OV', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_Double1s'), { dex: 20 });
+            await openDexRollDialog(page, actorId);
+            await fillRollDialog(page, { av: 20, ev: 5, ov: 1, rv: 1 });
+
+            await queueDice(page, [1, 1]);
+            const before = await getChatMessageCount(page);
+            await submitRollDialog(page, before);
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.resultText).toContain('Double 1s: Automatic failure!');
+            expect(msg.isFailure).toBe(true);
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Column shift earned by high roll increases RAPs (AV 5 vs OV 3, roll 13)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_ColShift'));
+            await openDexRollDialog(page, actorId);
+            await fillRollDialog(page, { av: 5, ev: 5, ov: 3, rv: 5 });
+
+            // Difficulty = actionTable[3][2] = 9. Roll 13 beats the 11 column
+            // but not the 13 column => exactly 1 column shift.
+            // EV 5 vs RV 5 is normally 1 RAP; shifted one column => 2 RAPs.
+            await queueDice(page, [7, 6]);
+            const before = await getChatMessageCount(page);
+            await submitRollDialog(page, before);
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.difficulty).toBe(9);
+            expect(msg.rollTotal).toBe(13);
+            expect(msg.raw).toMatch(/1\s+Column Shift/);
+            expect(msg.resultText).toContain('Success: 2 RAPs!');
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Positive Result Table shifts increase RAPs (+2 shifts: 1 RAP becomes 3)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_PlusShifts'));
+            await openDexRollDialog(page, actorId);
+            await fillRollDialog(page, { av: 5, ev: 5, ov: 5, rv: 5, resultShifts: 2 });
+
+            // Roll 11 earns no shifts of its own; +2 manual shifts move
+            // EV 5 vs RV 5 from resultTable[3][3]=1 to resultTable[3][1]=3.
+            await queueDice(page, [6, 5]);
+            const before = await getChatMessageCount(page);
+            await submitRollDialog(page, before);
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.difficulty).toBe(11);
+            expect(msg.resultText).toContain('Success: 3 RAPs!');
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Negative Result Table shifts can reduce the result to No Effect', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_MinusShifts'));
+            await openDexRollDialog(page, actorId);
+            await fillRollDialog(page, { av: 5, ev: 5, ov: 5, rv: 5, resultShifts: -2 });
+
+            // EV 5 vs RV 5 shifted -2 lands on resultTable[3][5] = 0 => No Effect.
+            await queueDice(page, [6, 5]);
+            const before = await getChatMessageCount(page);
+            await submitRollDialog(page, before);
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.resultText).toContain('No effect!');
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('RV 0 gives the "All" result: RAPs equal Effect Value', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_AllResult'));
+            await openDexRollDialog(page, actorId);
+            await fillRollDialog(page, { av: 5, ev: 5, ov: 5, rv: 0 });
+
+            await queueDice(page, [6, 5]);
+            const before = await getChatMessageCount(page);
+            await submitRollDialog(page, before);
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.resultText).toContain('Success: 5 RAPs!');
+            expect(msg.evResult).toContain('A (5)');
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Doubles prompt to roll again; accepted reroll adds to the total', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_Doubles'));
+            await openDexRollDialog(page, actorId);
+            await fillRollDialog(page, { av: 5, ev: 5, ov: 5, rv: 5 });
+
+            // 4+4 doubles, then 5+3 => total 16.
+            // Roll 16 earns 2 column shifts (beats 13 and 15 columns);
+            // EV 5 vs RV 5 shifted 2 => resultTable[3][1] = 3 RAPs.
+            await queueDice(page, [4, 4, 5, 3]);
+            const before = await getChatMessageCount(page);
+            await clickRollDialogSubmit(page);
+            await answerDoublesPrompt(page, true);
+
+            await page.waitForFunction(
+                (b) => document.querySelectorAll('.chat-log .chat-message').length > b,
+                before,
+                { timeout: 15000 }
+            );
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.dice).toEqual([4, 4, 5, 3]);
+            expect(msg.rollTotal).toBe(16);
+            expect(msg.resultText).toContain('Success: 3 RAPs!');
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Doubles declined keeps the original total', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_DoublesNo'));
+            await openDexRollDialog(page, actorId);
+            await fillRollDialog(page, { av: 5, ev: 5, ov: 5, rv: 5 });
+
+            await queueDice(page, [4, 4]); // total 8 < difficulty 11
+            const before = await getChatMessageCount(page);
+            await clickRollDialogSubmit(page);
+            await answerDoublesPrompt(page, false);
+
+            await page.waitForFunction(
+                (b) => document.querySelectorAll('.chat-log .chat-message').length > b,
+                before,
+                { timeout: 15000 }
+            );
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.dice).toEqual([4, 4]);
+            expect(msg.rollTotal).toBe(8);
+            expect(msg.resultText).toContain('Action failed!');
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Consecutive doubles accumulate across multiple rerolls', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AR_ConsecDoubles'));
+            await openDexRollDialog(page, actorId);
+            await fillRollDialog(page, { av: 5, ev: 5, ov: 5, rv: 5 });
+
+            // 2+2 doubles, 3+3 doubles, 6+4 => total 20 over 6 dice.
+            // Roll 20 earns 3 shifts (beats 13, 15, 18); EV 5 vs RV 5
+            // shifted 3 pushes past column 0 => All result = 5 RAPs.
+            await queueDice(page, [2, 2, 3, 3, 6, 4]);
+            const before = await getChatMessageCount(page);
+            await clickRollDialogSubmit(page);
+            await answerDoublesPrompt(page, true);
+            await answerDoublesPrompt(page, true);
+
+            await page.waitForFunction(
+                (b) => document.querySelectorAll('.chat-log .chat-message').length > b,
+                before,
+                { timeout: 15000 }
+            );
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.dice).toEqual([2, 2, 3, 3, 6, 4]);
+            expect(msg.rollTotal).toBe(20);
+            expect(msg.resultText).toContain('Success: 5 RAPs!');
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/active-effects.spec.mjs
+++ b/e2e/tests/active-effects.spec.mjs
@@ -1,0 +1,112 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    deleteActor,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+/**
+ * Category 10 of #226: Active Effects.
+ *
+ * NOTE: The MEGS actor sheet does not currently render an Active Effects
+ * panel (module/sheets/actor-sheet.mjs has the effect preparation commented
+ * out as a TODO), so the sheet-level checklist items (edit button, delete
+ * confirmation dialog, category display) cannot be exercised through the UI
+ * yet. These tests cover the document-level behavior the eventual UI will
+ * sit on: creating, toggling, categorizing, and deleting effects on actors.
+ */
+test.describe('Active Effects (#226 cat 10)', () => {
+    test('Creating an Active Effect on an actor works', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AE_Create'));
+            const effect = await page.evaluate(async (id) => {
+                const actor = game.actors.get(id);
+                const [created] = await actor.createEmbeddedDocuments('ActiveEffect', [{
+                    name: 'Blessing',
+                    icon: 'icons/svg/aura.svg',
+                    changes: [{ key: 'system.attributes.str.value', mode: 2, value: '2' }],
+                }]);
+                return { id: created.id, name: created.name, count: actor.effects.size };
+            }, actorId);
+            expect(effect.name).toBe('Blessing');
+            expect(effect.count).toBe(1);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Toggling an Active Effect enables and disables it', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AE_Toggle'));
+            const states = await page.evaluate(async (id) => {
+                const actor = game.actors.get(id);
+                const [effect] = await actor.createEmbeddedDocuments('ActiveEffect', [{
+                    name: 'Slow', icon: 'icons/svg/anchor.svg',
+                }]);
+                const initial = effect.disabled;
+                await effect.update({ disabled: true });
+                const afterDisable = actor.effects.get(effect.id).disabled;
+                await effect.update({ disabled: false });
+                const afterEnable = actor.effects.get(effect.id).disabled;
+                return { initial, afterDisable, afterEnable };
+            }, actorId);
+            expect(states.initial).toBe(false);
+            expect(states.afterDisable).toBe(true);
+            expect(states.afterEnable).toBe(false);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Effects categorize as temporary, passive, and inactive', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AE_Categories'));
+            const categories = await page.evaluate(async (id) => {
+                const actor = game.actors.get(id);
+                const [temporary, passive, inactive] = await actor.createEmbeddedDocuments('ActiveEffect', [
+                    { name: 'Stunned', icon: 'icons/svg/daze.svg', duration: { rounds: 2 } },
+                    { name: 'Tough', icon: 'icons/svg/shield.svg' },
+                    { name: 'Dormant', icon: 'icons/svg/sleep.svg', disabled: true },
+                ]);
+                return {
+                    temporaryIsTemporary: temporary.isTemporary,
+                    passiveIsTemporary: passive.isTemporary,
+                    inactiveDisabled: inactive.disabled,
+                };
+            }, actorId);
+            expect(categories.temporaryIsTemporary).toBe(true);
+            expect(categories.passiveIsTemporary).toBe(false);
+            expect(categories.inactiveDisabled).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Deleting an Active Effect removes it from the actor', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('AE_Delete'));
+            const result = await page.evaluate(async (id) => {
+                const actor = game.actors.get(id);
+                const [effect] = await actor.createEmbeddedDocuments('ActiveEffect', [{
+                    name: 'Doomed', icon: 'icons/svg/skull.svg',
+                }]);
+                const beforeDelete = actor.effects.size;
+                await effect.delete();
+                return { beforeDelete, afterDelete: actor.effects.size };
+            }, actorId);
+            expect(result.beforeDelete).toBe(1);
+            expect(result.afterDelete).toBe(0);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/actor-sheets.spec.mjs
+++ b/e2e/tests/actor-sheets.spec.mjs
@@ -1,0 +1,249 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    deleteActor,
+    openActorSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+/**
+ * Categories 2 + 3 of #226: Actor Sheets.
+ * Hero / Villain / NPC sheets render all tabs with the 9 attributes,
+ * derived values calculate, attributes are editable; Location and
+ * Vehicle sheets render.
+ */
+test.describe('Actor Sheets (#226 cats 2-3)', () => {
+    // Attribute labels are localized full names on the sheet
+    const ATTRIBUTE_LABELS = ['Dexterity', 'Strength', 'Body', 'Intelligence', 'Will', 'Mind', 'Influence', 'Aura', 'Spirit'];
+    const TAB_NAMES = ['abilities', 'powers', 'skills', 'traits', 'gadgets', 'description'];
+
+    async function createActorOfType(page, name, type) {
+        return page.evaluate(async ({ name, type }) => {
+            const actor = await Actor.create({ name, type });
+            return actor.id;
+        }, { name, type });
+    }
+
+    /** Open the sheet and click through every tab, asserting each becomes active. */
+    async function verifyAllTabsRender(page, actorId) {
+        await openActorSheet(page, actorId);
+        for (const tab of TAB_NAMES) {
+            await page.click(`.sheet.actor nav.sheet-tabs .item[data-tab="${tab}"]`);
+            await page.waitForFunction(
+                (t) => {
+                    const el = document.querySelector(`.sheet.actor .tab[data-tab="${t}"]`);
+                    return el && el.classList.contains('active');
+                },
+                tab,
+                { timeout: 5000 }
+            );
+        }
+    }
+
+    async function getDisplayedAttributes(page) {
+        return page.evaluate(() => {
+            const out = {};
+            const cells = document.querySelectorAll('.sheet.actor .tab.abilities .attribute');
+            for (const cell of cells) {
+                const label = cell.querySelector('label')?.textContent.trim();
+                // Edit mode renders an input, view mode a plain div
+                const input = cell.querySelector('.attribute-input input');
+                const value = input ? input.value : cell.querySelector('label + div')?.textContent.trim();
+                if (label) out[label] = value;
+            }
+            return out;
+        });
+    }
+
+    test('Hero sheet opens and renders all tabs', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Sheet_Hero'));
+            await verifyAllTabsRender(page, actorId);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Villain sheet opens and renders all tabs', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createActorOfType(page, prefixName('Sheet_Villain'), 'villain');
+            await verifyAllTabsRender(page, actorId);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('NPC sheet opens and renders all tabs', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createActorOfType(page, prefixName('Sheet_NPC'), 'npc');
+            await verifyAllTabsRender(page, actorId);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('All 9 attributes display with their values on the hero sheet', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Sheet_Attrs'));
+            await openActorSheet(page, actorId, 'abilities');
+
+            const attrs = await getDisplayedAttributes(page);
+            for (const label of ATTRIBUTE_LABELS) {
+                expect(Object.keys(attrs), `attribute ${label} shown`).toContain(label);
+            }
+            expect(attrs.Dexterity).toBe('5');
+            expect(attrs.Strength).toBe('4');
+            expect(attrs.Body).toBe('4');
+            expect(attrs.Spirit).toBe('2');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Derived values: initiative bonus, hero points, current BODY', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Sheet_Derived'));
+
+            // Initiative bonus = DEX + INT + INFL = 5 + 3 + 2 = 10 (no bonus
+            // abilities). It is computed during sheet rendering, so it is
+            // asserted from the rendered sheet below, not the document.
+            await openActorSheet(page, actorId, 'abilities');
+
+            const derived = await page.evaluate((id) => {
+                const actor = game.actors.get(id);
+                return {
+                    heroPoints: actor.system.heroPoints.value,
+                    currentBody: actor.system.currentBody.value,
+                };
+            }, actorId);
+            expect(derived.heroPoints).toBe(10);
+            const displayed = await page.evaluate(() => {
+                const initEl = document.querySelector('.sheet.actor .initiative .tooltip');
+                const hpInput = document.querySelector('.sheet.actor .hero-points input');
+                const bodyInput = document.querySelector('.sheet.actor .sheet-header input[id*="currentBody"], .sheet.actor .sheet-header [name*="currentBody"]');
+                return {
+                    initiative: initEl ? initEl.childNodes[0].textContent.trim() : null,
+                    heroPoints: hpInput ? hpInput.value : null,
+                    currentBody: bodyInput ? bodyInput.value : null,
+                    currentBodyMax: bodyInput ? bodyInput.getAttribute('max') : null,
+                };
+            });
+            expect(displayed.initiative).toBe('10');
+            expect(displayed.heroPoints).toBe('10');
+            // Fresh actors start Current Body at 0; the input is capped at BODY
+            expect(displayed.currentBody).toBe(String(derived.currentBody));
+            expect(displayed.currentBodyMax).toBe('4');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Attributes are editable in edit mode and persist', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Sheet_Edit'));
+            await page.evaluate(async (id) => {
+                await game.actors.get(id).setFlag('megs', 'edit-mode', true);
+            }, actorId);
+            await openActorSheet(page, actorId, 'abilities');
+            await page.waitForSelector('.sheet.actor input[name="system.attributes.dex.value"]', { timeout: 5000 });
+
+            await page.fill('.sheet.actor input[name="system.attributes.dex.value"]', '7');
+            await page.dispatchEvent('.sheet.actor input[name="system.attributes.dex.value"]', 'change');
+
+            await page.waitForFunction(
+                (id) => game.actors.get(id).system.attributes.dex.value === 7,
+                actorId,
+                { timeout: 5000 }
+            );
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Attribute +/- controls adjust the input value', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Sheet_PlusMinus'));
+            await page.evaluate(async (id) => {
+                await game.actors.get(id).setFlag('megs', 'edit-mode', true);
+            }, actorId);
+            await openActorSheet(page, actorId, 'abilities');
+            await page.waitForSelector('.sheet.actor input[name="system.attributes.dex.value"]', { timeout: 5000 });
+
+            const readDex = () => page.evaluate(() =>
+                document.querySelector('.sheet.actor input[name="system.attributes.dex.value"]').value);
+
+            expect(await readDex()).toBe('5');
+            await page.evaluate(() => {
+                document.querySelector('.sheet.actor input[name="system.attributes.dex.value"]')
+                    .closest('.quantity').querySelector('button.plus').click();
+            });
+            expect(await readDex()).toBe('6');
+            await page.evaluate(() => {
+                document.querySelector('.sheet.actor input[name="system.attributes.dex.value"]')
+                    .closest('.quantity').querySelector('button.minus').click();
+            });
+            expect(await readDex()).toBe('5');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Location sheet opens and renders tabs with attributes', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createActorOfType(page, prefixName('Sheet_Location'), 'location');
+            await verifyAllTabsRender(page, actorId);
+
+            const attrs = await getDisplayedAttributes(page);
+            for (const label of ATTRIBUTE_LABELS) {
+                expect(Object.keys(attrs), `attribute ${label} shown`).toContain(label);
+            }
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Vehicle sheet opens and renders its header (Owner field)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createActorOfType(page, prefixName('Sheet_Vehicle'), 'vehicle');
+            await openActorSheet(page, actorId);
+
+            // A vehicle without a linked item shows only the header with the
+            // Owner selector; the tab body renders once linked.
+            const header = await page.evaluate(() => {
+                const sheet = document.querySelector('.sheet.actor form.vehicle');
+                if (!sheet) return null;
+                // Name is an input in edit mode, a div in view mode
+                const nameInput = sheet.querySelector('h1.charname input[name="name"]');
+                const nameDiv = sheet.querySelector('h1.charname div[name="name"]');
+                return {
+                    hasOwnerLabel: !!sheet.querySelector('label[for="system.ownerId"]'),
+                    name: nameInput ? nameInput.value : (nameDiv?.textContent.trim() ?? null),
+                };
+            });
+            expect(header).not.toBeNull();
+            expect(header.hasOwnerLabel).toBe(true);
+            expect(header.name).toContain('Sheet_Vehicle');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/actor-sheets.spec.mjs
+++ b/e2e/tests/actor-sheets.spec.mjs
@@ -25,9 +25,13 @@ test.describe('Actor Sheets (#226 cats 2-3)', () => {
         }, { name, type });
     }
 
-    /** Open the sheet and click through every tab, asserting each becomes active. */
-    async function verifyAllTabsRender(page, actorId) {
+    /**
+     * Open the sheet and click through every tab.
+     * Returns the tabs that became active so callers can assert on them.
+     */
+    async function clickThroughAllTabs(page, actorId) {
         await openActorSheet(page, actorId);
+        const activated = [];
         for (const tab of TAB_NAMES) {
             await page.click(`.sheet.actor nav.sheet-tabs .item[data-tab="${tab}"]`);
             await page.waitForFunction(
@@ -38,7 +42,9 @@ test.describe('Actor Sheets (#226 cats 2-3)', () => {
                 tab,
                 { timeout: 5000 }
             );
+            activated.push(tab);
         }
+        return activated;
     }
 
     async function getDisplayedAttributes(page) {
@@ -60,7 +66,8 @@ test.describe('Actor Sheets (#226 cats 2-3)', () => {
         let actorId;
         try {
             actorId = await createHeroActor(page, prefixName('Sheet_Hero'));
-            await verifyAllTabsRender(page, actorId);
+            const activated = await clickThroughAllTabs(page, actorId);
+            expect(activated).toEqual(TAB_NAMES);
         } finally {
             await closeAllWindows(page);
             if (actorId) await deleteActor(page, actorId);
@@ -71,7 +78,8 @@ test.describe('Actor Sheets (#226 cats 2-3)', () => {
         let actorId;
         try {
             actorId = await createActorOfType(page, prefixName('Sheet_Villain'), 'villain');
-            await verifyAllTabsRender(page, actorId);
+            const activated = await clickThroughAllTabs(page, actorId);
+            expect(activated).toEqual(TAB_NAMES);
         } finally {
             await closeAllWindows(page);
             if (actorId) await deleteActor(page, actorId);
@@ -82,7 +90,8 @@ test.describe('Actor Sheets (#226 cats 2-3)', () => {
         let actorId;
         try {
             actorId = await createActorOfType(page, prefixName('Sheet_NPC'), 'npc');
-            await verifyAllTabsRender(page, actorId);
+            const activated = await clickThroughAllTabs(page, actorId);
+            expect(activated).toEqual(TAB_NAMES);
         } finally {
             await closeAllWindows(page);
             if (actorId) await deleteActor(page, actorId);
@@ -167,6 +176,11 @@ test.describe('Actor Sheets (#226 cats 2-3)', () => {
                 actorId,
                 { timeout: 5000 }
             );
+            const persisted = await page.evaluate(
+                (id) => game.actors.get(id).system.attributes.dex.value,
+                actorId
+            );
+            expect(persisted).toBe(7);
         } finally {
             await closeAllWindows(page);
             if (actorId) await deleteActor(page, actorId);
@@ -207,7 +221,8 @@ test.describe('Actor Sheets (#226 cats 2-3)', () => {
         let actorId;
         try {
             actorId = await createActorOfType(page, prefixName('Sheet_Location'), 'location');
-            await verifyAllTabsRender(page, actorId);
+            const activated = await clickThroughAllTabs(page, actorId);
+            expect(activated).toEqual(TAB_NAMES);
 
             const attrs = await getDisplayedAttributes(page);
             for (const label of ATTRIBUTE_LABELS) {

--- a/e2e/tests/chat-message-formatting.spec.mjs
+++ b/e2e/tests/chat-message-formatting.spec.mjs
@@ -1,0 +1,153 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    addPowerToActor,
+    deleteActor,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+import {
+    getChatMessageCount,
+    getLatestChatMessage,
+    waitForRollDialog,
+    submitRollDialog,
+} from '../fixtures/roll-helpers.mjs';
+
+test.describe('Chat Message Formatting (#93)', () => {
+    test('Chat message includes avatar image after a roll', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ChatFmt_Avatar'));
+            await addPowerToActor(page, actorId, {
+                name: 'Flame Project',
+                aps: 8,
+                link: 'str',
+                source: 'physical',
+            });
+
+            // Trigger a roll via the item's roll() method
+            await page.evaluate((id) => {
+                const actor = game.actors.get(id);
+                const power = actor.items.find(i => i.type === 'power' && i.name === 'Flame Project');
+                power.roll();
+            }, actorId);
+
+            await waitForRollDialog(page);
+
+            const beforeCount = await getChatMessageCount(page);
+            await submitRollDialog(page, beforeCount);
+
+            const msg = await getLatestChatMessage(page);
+            expect(msg).not.toBeNull();
+            expect(msg.html).toContain('megs-chat-avatar');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Chat message contains collapsible <details> element', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ChatFmt_Details'));
+            await addPowerToActor(page, actorId, {
+                name: 'Heat Vision',
+                aps: 10,
+                link: 'str',
+                source: 'physical',
+            });
+
+            await page.evaluate((id) => {
+                const actor = game.actors.get(id);
+                const power = actor.items.find(i => i.type === 'power' && i.name === 'Heat Vision');
+                power.roll();
+            }, actorId);
+
+            await waitForRollDialog(page);
+
+            const beforeCount = await getChatMessageCount(page);
+            await submitRollDialog(page, beforeCount);
+
+            const msg = await getLatestChatMessage(page);
+            expect(msg).not.toBeNull();
+            expect(msg.html).toContain('<details');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Chat message has success or failure styling class', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ChatFmt_Style'));
+            await addPowerToActor(page, actorId, {
+                name: 'Super Breath',
+                aps: 6,
+                link: 'str',
+                source: 'physical',
+            });
+
+            await page.evaluate((id) => {
+                const actor = game.actors.get(id);
+                const power = actor.items.find(i => i.type === 'power' && i.name === 'Super Breath');
+                power.roll();
+            }, actorId);
+
+            await waitForRollDialog(page);
+
+            const beforeCount = await getChatMessageCount(page);
+            await submitRollDialog(page, beforeCount);
+
+            const msg = await getLatestChatMessage(page);
+            expect(msg).not.toBeNull();
+
+            // The rollResult.hbs template always adds either 'success' or 'failure' class
+            // to the chat-result div within the summary
+            const hasResultStyling = msg.html.includes('success') || msg.html.includes('failure');
+            expect(hasResultStyling).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Chat message contains expected roll structure elements', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ChatFmt_Struct'));
+            await addPowerToActor(page, actorId, {
+                name: 'Lightning',
+                aps: 9,
+                link: 'str',
+                source: 'physical',
+            });
+
+            await page.evaluate((id) => {
+                const actor = game.actors.get(id);
+                const power = actor.items.find(i => i.type === 'power' && i.name === 'Lightning');
+                power.roll();
+            }, actorId);
+
+            await waitForRollDialog(page);
+
+            const beforeCount = await getChatMessageCount(page);
+            await submitRollDialog(page, beforeCount);
+
+            const msg = await getLatestChatMessage(page);
+            expect(msg).not.toBeNull();
+
+            // Verify the megs-chat-roll wrapper from rollResult.hbs
+            expect(msg.html).toContain('megs-chat-roll');
+
+            // Verify the dice display elements exist
+            expect(msg.html).toContain('d10');
+
+            // Verify the chat-result summary section exists
+            expect(msg.html).toContain('chat-result');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/combat-maneuvers.spec.mjs
+++ b/e2e/tests/combat-maneuvers.spec.mjs
@@ -1,0 +1,221 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    deleteActor,
+    openActorSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+import {
+    waitForRollDialog,
+    fillRollDialog,
+    submitRollDialog,
+    queueDice,
+    restoreDice,
+    getChatMessageCount,
+    parseLatestRollMessage,
+} from '../fixtures/roll-helpers.mjs';
+
+/**
+ * Category 7 of #226: Combat Maneuvers (3E Rules Ch. 2).
+ *
+ * Maneuver OV/RV shifts come from assets/data/combatManeuvers.json and are
+ * applied in dice.mjs _handleRolls: ovShifts move the OV column used for the
+ * Action Table difficulty lookup (negative ovShifts = higher difficulty),
+ * and rvShifts feed into the Result Table column shifts.
+ *
+ * Expected difficulties are hardcoded from actionTable[3] (AV 5-6):
+ *   [4, 7, 9, 11, 13, 15, 18, 21] for OV columns 0..7.
+ * Base case AV 5 vs OV 5 is column 3 => difficulty 11.
+ */
+test.describe('Combat Maneuvers (#226 cat 7)', () => {
+    async function openDexRollDialog(page, actorId) {
+        await page.evaluate(() => {
+            for (const t of [...game.user.targets]) {
+                t.setTarget(false, { user: game.user, releaseOthers: false });
+            }
+        });
+        await openActorSheet(page, actorId, 'abilities');
+        await page.click('.sheet.actor .tab.abilities .resource-label.rollable[data-key="dex"]');
+        await waitForRollDialog(page);
+    }
+
+    /** Roll AV 5 / EV 5 / OV 5 / RV 5 with the given maneuver and dice. */
+    async function rollWithManeuver(page, actorId, maneuver, dice) {
+        await openDexRollDialog(page, actorId);
+        await fillRollDialog(page, { av: 5, ev: 5, ov: 5, rv: 5, maneuver });
+        await queueDice(page, dice);
+        const before = await getChatMessageCount(page);
+        await submitRollDialog(page, before);
+        return parseLatestRollMessage(page);
+    }
+
+    test('Roll dialog maneuver select lists the combat maneuvers', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('CM_Select'));
+            await openDexRollDialog(page, actorId);
+
+            const options = await page.evaluate(() => {
+                const select = document.querySelector('.dialog .megs-dialog select[name="combatManeuver"]');
+                return select ? [...select.options].map(o => o.value) : null;
+            });
+
+            expect(options).not.toBeNull();
+            expect(options[0]).toBe(''); // "None" default
+            for (const maneuver of [
+                'Critical Blow',
+                'Devastating Attack',
+                'Flailing Attack',
+                'Grappling Attack',
+                'Multi-Attack vs 2',
+                'Multi-Attack vs 3-4',
+                'Multi-Attack vs 5-8',
+                'Pulling a Punch',
+                'Pressing the Attack',
+            ]) {
+                expect(options).toContain(maneuver);
+            }
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Critical Blow shifts OV 2 columns against the attacker (difficulty 11 -> 15)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('CM_CritBlow'));
+            const msg = await rollWithManeuver(page, actorId, 'Critical Blow', [6, 5]);
+            expect(msg.difficulty).toBe(15);
+            expect(msg.rollTotal).toBe(11);
+            expect(msg.resultText).toContain('Action failed!'); // 11 < 15
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Devastating Attack shifts OV 4 columns (difficulty 11 -> 21)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('CM_Devastating'));
+            const msg = await rollWithManeuver(page, actorId, 'Devastating Attack', [6, 5]);
+            expect(msg.difficulty).toBe(21);
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Flailing Attack shifts OV 2 columns in the attacker\'s favor (difficulty 11 -> 7)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('CM_Flailing'));
+            const msg = await rollWithManeuver(page, actorId, 'Flailing Attack', [6, 5]);
+            expect(msg.difficulty).toBe(7);
+            expect(msg.isSuccess).toBe(true); // 11 >= 7
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Grappling Attack applies no column shifts (difficulty stays 11)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('CM_Grapple'));
+            const msg = await rollWithManeuver(page, actorId, 'Grappling Attack', [6, 5]);
+            expect(msg.difficulty).toBe(11);
+            expect(msg.isSuccess).toBe(true);
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Multi-Attack vs 2 targets: OV shifted 1 column (difficulty 13), RV +1 shift', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('CM_Multi2'));
+            // Roll 13 exactly meets difficulty 13; no roll shifts.
+            // RV index = rangeIndex(5) + ovShifts(-1) = 2, then rvShifts +1
+            // moves it to column 1 => resultTable[3][1] = 3 RAPs.
+            const msg = await rollWithManeuver(page, actorId, 'Multi-Attack vs 2', [7, 6]);
+            expect(msg.difficulty).toBe(13);
+            expect(msg.isSuccess).toBe(true);
+            expect(msg.resultText).toContain('Success: 3 RAPs!');
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Multi-Attack vs 3-4 targets: OV shifted 2 columns (difficulty 15)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('CM_Multi34'));
+            const msg = await rollWithManeuver(page, actorId, 'Multi-Attack vs 3-4', [6, 5]);
+            expect(msg.difficulty).toBe(15);
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Multi-Attack vs 5-8 targets: OV shifted 3 columns (difficulty 18)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('CM_Multi58'));
+            const msg = await rollWithManeuver(page, actorId, 'Multi-Attack vs 5-8', [6, 5]);
+            expect(msg.difficulty).toBe(18);
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Pressing the Attack shifts OV 1 column against the attacker (difficulty 13)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('CM_Pressing'));
+            const msg = await rollWithManeuver(page, actorId, 'Pressing the Attack', [6, 5]);
+            expect(msg.difficulty).toBe(13);
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Pulling a Punch: manually reduced EV lowers the RAPs result', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('CM_PullPunch'));
+            await openDexRollDialog(page, actorId);
+            // Pull the punch by dropping EV from 5 to 3.
+            // EV 3 vs RV 3 => resultTable[2][2] = 1 RAP (EV 5 would give 2).
+            await fillRollDialog(page, { av: 5, ev: 3, ov: 5, rv: 3 });
+            await queueDice(page, [6, 5]);
+            const before = await getChatMessageCount(page);
+            await submitRollDialog(page, before);
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.difficulty).toBe(11);
+            expect(msg.isSuccess).toBe(true);
+            expect(msg.raw).toMatch(/Effect Value\s*3/);
+            expect(msg.resultText).toContain('Success: 1 RAPs!');
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/drag-drop.spec.mjs
+++ b/e2e/tests/drag-drop.spec.mjs
@@ -1,0 +1,236 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    addPowerToActor,
+    addTraitToActor,
+    deleteActor,
+    openActorSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+/**
+ * Category 5 of #226: Drag & Drop.
+ * Drops are exercised through the same code paths the UI uses:
+ * ActorSheet._onDropItemCreate for sheet drops, and real DragEvents with a
+ * DataTransfer payload for the power-row bonus/limitation drop zones.
+ */
+test.describe('Drag & Drop (#226 cat 5)', () => {
+    /** Fetch the first document of a compendium pack and drop it on the actor sheet. */
+    async function dropFromCompendium(page, actorId, packName) {
+        return page.evaluate(async ({ actorId, packName }) => {
+            const pack = game.packs.get(packName);
+            if (!pack) return { error: `pack ${packName} not found` };
+            const index = await pack.getIndex();
+            const first = index.contents[0];
+            const doc = await pack.getDocument(first._id);
+            const actor = game.actors.get(actorId);
+            const created = await actor.sheet._onDropItemCreate(doc.toObject());
+            return {
+                name: doc.name,
+                type: doc.type,
+                createdCount: Array.isArray(created) ? created.length : (created ? 1 : 0),
+            };
+        }, { actorId, packName });
+    }
+
+    test('Dragging a power from the compendium onto an actor adds it', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Drop_Power'));
+            const result = await dropFromCompendium(page, actorId, 'megs.powers');
+            expect(result.error).toBeUndefined();
+            expect(result.type).toBe('power');
+
+            const onActor = await page.evaluate(({ actorId, name }) => {
+                const actor = game.actors.get(actorId);
+                return actor.items.some(i => i.type === 'power' && i.name === name);
+            }, { actorId, name: result.name });
+            expect(onActor).toBe(true);
+
+            // Visible on the Powers tab
+            await openActorSheet(page, actorId, 'powers');
+            const visible = await page.evaluate((name) => {
+                const tab = document.querySelector('.sheet.actor .tab.powers');
+                return tab ? tab.textContent.includes(name) : false;
+            }, result.name);
+            expect(visible).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Dragging a skill from the compendium onto an actor adds it', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Drop_Skill'));
+            const result = await dropFromCompendium(page, actorId, 'world.megs-skills');
+            expect(result.error).toBeUndefined();
+
+            const onActor = await page.evaluate(({ actorId, name }) => {
+                const actor = game.actors.get(actorId);
+                return actor.items.some(i => i.name === name);
+            }, { actorId, name: result.name });
+            expect(onActor).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Dragging an advantage from the compendium onto an actor adds it', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Drop_Adv'));
+            const result = await dropFromCompendium(page, actorId, 'megs.advantages');
+            expect(result.error).toBeUndefined();
+            expect(result.type).toBe('advantage');
+
+            const onActor = await page.evaluate(({ actorId, name }) => {
+                const actor = game.actors.get(actorId);
+                return actor.items.some(i => i.type === 'advantage' && i.name === name);
+            }, { actorId, name: result.name });
+            expect(onActor).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Dropping a bonus onto a power row attaches it to that power', async ({ page }) => {
+        let actorId;
+        let worldItemId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Drop_Bonus'));
+            const powerId = await addPowerToActor(page, actorId, {
+                name: 'Lightning', aps: 5, factorCost: 3,
+            });
+
+            // World-level bonus item to drag in
+            worldItemId = await page.evaluate(async (name) => {
+                const item = await Item.create({
+                    name, type: 'bonus', system: { factorCostMod: 1 },
+                });
+                return item.id;
+            }, prefixName('AreaEffectBonus'));
+
+            await openActorSheet(page, actorId, 'powers');
+
+            // Dispatch a real drop event on the power row
+            const dropped = await page.evaluate(async ({ powerId, worldItemId }) => {
+                const row = document.querySelector(`.sheet.actor .tab.powers .power-row[data-item-id="${powerId}"]`);
+                if (!row) return { error: 'power row not found' };
+                const item = game.items.get(worldItemId);
+                const dt = new DataTransfer();
+                dt.setData('text/plain', JSON.stringify({ type: 'Item', uuid: item.uuid }));
+                row.dispatchEvent(new DragEvent('drop', { dataTransfer: dt, bubbles: true, cancelable: true }));
+                return {};
+            }, { powerId, worldItemId });
+            expect(dropped.error).toBeUndefined();
+
+            await page.waitForFunction(
+                ({ actorId, powerId }) => {
+                    const actor = game.actors.get(actorId);
+                    return actor.items.some(i => i.type === 'bonus' && i.system.parent === powerId);
+                },
+                { actorId, powerId },
+                { timeout: 10000 }
+            );
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+            if (worldItemId) {
+                await page.evaluate(async (id) => {
+                    const item = game.items.get(id);
+                    if (item) await item.delete();
+                }, worldItemId);
+            }
+        }
+    });
+
+    test('Dropping a gadget onto an actor adds it to the Gadgets tab', async ({ page }) => {
+        let actorId;
+        let worldItemId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Drop_Gadget'));
+
+            worldItemId = await page.evaluate(async (name) => {
+                const item = await Item.create({
+                    name,
+                    type: 'gadget',
+                    system: { actionValue: 3, effectValue: 3 },
+                });
+                return item.id;
+            }, prefixName('GrappleGun'));
+
+            const result = await page.evaluate(async ({ actorId, worldItemId }) => {
+                const actor = game.actors.get(actorId);
+                const item = game.items.get(worldItemId);
+                const created = await actor.sheet._onDropItemCreate(item.toObject());
+                return { createdCount: Array.isArray(created) ? created.length : 0 };
+            }, { actorId, worldItemId });
+            expect(result.createdCount).toBeGreaterThan(0);
+
+            await openActorSheet(page, actorId, 'gadgets');
+            const visible = await page.evaluate((name) => {
+                const tab = document.querySelector('.sheet.actor .tab.gadgets');
+                return tab ? tab.textContent.includes(name) : false;
+            }, prefixName('GrappleGun'));
+            expect(visible).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+            if (worldItemId) {
+                await page.evaluate(async (id) => {
+                    const item = game.items.get(id);
+                    if (item) await item.delete();
+                }, worldItemId);
+            }
+        }
+    });
+
+    test('Removing an item from an actor works (delete control + confirm)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Drop_Delete'));
+            const traitId = await addTraitToActor(page, actorId, {
+                name: 'Expendable Trait', type: 'advantage', baseCost: 5,
+            });
+
+            // Delete controls only render in edit mode
+            await page.evaluate(async (id) => {
+                await game.actors.get(id).setFlag('megs', 'edit-mode', true);
+            }, actorId);
+            await openActorSheet(page, actorId, 'traits');
+
+            await page.evaluate((itemId) => {
+                const row = document.querySelector(`.sheet.actor .tab.traits .item[data-item-id="${itemId}"]`);
+                if (!row) throw new Error('trait row not found');
+                row.querySelector('.item-delete').click();
+            }, traitId);
+
+            // Confirm the deletion dialog
+            await page.waitForFunction(
+                () => [...document.querySelectorAll('.dialog')].some(d => d.textContent.includes('Are You Sure?')),
+                null,
+                { timeout: 5000 }
+            );
+            await page.evaluate(() => {
+                const dialog = [...document.querySelectorAll('.dialog')].find(d => d.textContent.includes('Are You Sure?'));
+                for (const btn of dialog.querySelectorAll('button')) {
+                    if (btn.textContent.trim().includes('Yes')) { btn.click(); return; }
+                }
+            });
+
+            await page.waitForFunction(
+                ({ actorId, traitId }) => !game.actors.get(actorId).items.get(traitId),
+                { actorId, traitId },
+                { timeout: 10000 }
+            );
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/drag-drop.spec.mjs
+++ b/e2e/tests/drag-drop.spec.mjs
@@ -228,6 +228,11 @@ test.describe('Drag & Drop (#226 cat 5)', () => {
                 { actorId, traitId },
                 { timeout: 10000 }
             );
+            const stillExists = await page.evaluate(
+                ({ actorId, traitId }) => !!game.actors.get(actorId).items.get(traitId),
+                { actorId, traitId }
+            );
+            expect(stillExists).toBe(false);
         } finally {
             await closeAllWindows(page);
             if (actorId) await deleteActor(page, actorId);

--- a/e2e/tests/gadget-integration.spec.mjs
+++ b/e2e/tests/gadget-integration.spec.mjs
@@ -1,0 +1,153 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    addGadgetToActor,
+    addPowerToActor,
+    addSkillToActor,
+    deleteActor,
+    openItemSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+/**
+ * Category 9 of #226 (gaps not already covered by gadget-rolling,
+ * gadget-sheet-rolling, and reliability-number specs): child powers/skills
+ * on gadgets, gadget attribute values, and the Omni-Gadget sheet variant.
+ */
+test.describe('Gadget Integration (#226 cat 9)', () => {
+    test('Power added to a gadget appears on the gadget sheet powers tab', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('GadgetInt_Power'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Power Armor', av: 0, ev: 0,
+            });
+            // The powers tab is gated on the hasPowers setting (string flag)
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const gadget = game.actors.get(actorId).items.get(gadgetId);
+                await gadget.update({ 'system.settings.hasPowers': 'true' });
+            }, { actorId, gadgetId });
+            await addPowerToActor(page, actorId, {
+                name: 'Armor Blast', aps: 6, factorCost: 3, parent: gadgetId,
+            });
+
+            await openItemSheet(page, actorId, gadgetId);
+            const tabs = await page.evaluate(() =>
+                [...document.querySelectorAll('.sheet.item nav.sheet-tabs .item')].map(a => a.dataset.tab));
+            expect(tabs).toContain('powers');
+
+            await page.click('.sheet.item nav.sheet-tabs .item[data-tab="powers"]');
+            const visible = await page.evaluate(() => {
+                const tab = document.querySelector('.sheet.item .tab[data-tab="powers"]');
+                return tab ? tab.textContent.includes('Armor Blast') : false;
+            });
+            expect(visible).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Skill added to a gadget appears on the gadget sheet skills tab', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('GadgetInt_Skill'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Spy Kit', av: 0, ev: 0,
+            });
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const gadget = game.actors.get(actorId).items.get(gadgetId);
+                await gadget.update({ 'system.settings.hasSkills': 'true' });
+            }, { actorId, gadgetId });
+            await addSkillToActor(page, actorId, {
+                name: 'Surveillance', aps: 4, factorCost: 3, parent: gadgetId,
+            });
+
+            await openItemSheet(page, actorId, gadgetId);
+            const tabs = await page.evaluate(() =>
+                [...document.querySelectorAll('.sheet.item nav.sheet-tabs .item')].map(a => a.dataset.tab));
+            expect(tabs).toContain('skills');
+
+            await page.click('.sheet.item nav.sheet-tabs .item[data-tab="skills"]');
+            const visible = await page.evaluate(() => {
+                const tab = document.querySelector('.sheet.item .tab[data-tab="skills"]');
+                return tab ? tab.textContent.includes('Surveillance') : false;
+            });
+            expect(visible).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Gadget attribute values are settable and display on the abilities tab', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('GadgetInt_Attrs'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Exo Frame',
+                av: 0,
+                ev: 0,
+                attrs: { dex: 6, str: 9, body: 8 },
+            });
+            // The attributes section renders when hasAttributes marks a
+            // category active; the gadget builder writes these as nested keys
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const gadget = game.actors.get(actorId).items.get(gadgetId);
+                await gadget.update({ 'system.settings.hasAttributes.physical': 'true' });
+            }, { actorId, gadgetId });
+
+            const stored = await page.evaluate(({ actorId, gadgetId }) => {
+                const gadget = game.actors.get(actorId).items.get(gadgetId);
+                const a = gadget.system.attributes;
+                return { dex: a.dex.value, str: a.str.value, body: a.body.value };
+            }, { actorId, gadgetId });
+            expect(stored).toEqual({ dex: 6, str: 9, body: 8 });
+
+            // Open in view mode; attribute labels localize to full names
+            await page.evaluate(async ({ actorId, itemId }) => {
+                const item = game.actors.get(actorId).items.get(itemId);
+                item.sheet; // eslint-disable-line no-unused-expressions -- construct first; constructor resets the flag
+                await item.setFlag('megs', 'edit-mode', false);
+            }, { actorId, itemId: gadgetId });
+            await openItemSheet(page, actorId, gadgetId);
+            const abilitiesText = await page.evaluate(() => {
+                const tab = document.querySelector('.sheet.item .tab[data-tab="abilities"]');
+                return tab ? tab.textContent.replace(/\s+/g, ' ') : '';
+            });
+            expect(abilitiesText).toContain('Dexterity 6');
+            expect(abilitiesText).toContain('Strength 9');
+            expect(abilitiesText).toContain('Body 8');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Omni-Gadget variant renders the omni header (quantity + APs)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('GadgetInt_Omni'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Omni Device', av: 0, ev: 0,
+            });
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const gadget = game.actors.get(actorId).items.get(gadgetId);
+                await gadget.update({ 'system.isOmni': 'true', 'system.aps': 8 });
+            }, { actorId, gadgetId });
+
+            await openItemSheet(page, actorId, gadgetId);
+            const omni = await page.evaluate(() => {
+                const sheet = document.querySelector('.sheet.item');
+                return {
+                    hasQuantity: !!sheet?.querySelector('label[for="system.quantity"]'),
+                };
+            });
+            expect(omni.hasQuantity).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/gadget-rolling.spec.mjs
+++ b/e2e/tests/gadget-rolling.spec.mjs
@@ -1,0 +1,731 @@
+/**
+ * E2E tests for Issue #17: Gadgets - Rolling
+ *
+ * These tests verify the REQUIREMENTS for gadget rolling behavior per MEGS RPG
+ * Chapter 7 rules, NOT the implementation. They are written adversarially
+ * to catch regressions and edge cases.
+ *
+ * All test actors and items are created fresh for each test and deleted
+ * afterward. No references to any specific IP or pre-existing world data.
+ *
+ * Requirements under test:
+ * R1. A gadget with explicit AV/EV should be rollable from the actor Gadgets tab.
+ * R2. A gadget with child powers (APs > 0) should be rollable.
+ * R3. A gadget with child skills (APs > 0) should be rollable.
+ * R4. A gadget with non-zero attribute pairs (DEX/STR, INT/WILL, INFL/AURA)
+ *     should be rollable.
+ * R5. A gadget with NONE of the above should NOT show a roll button.
+ * R6. When exactly one roll option exists, clicking the roll button should
+ *     proceed directly to the roll dialog (no picker).
+ * R7. When multiple roll options exist, clicking the roll button should open
+ *     a picker dialog listing all available options.
+ * R8. Child powers/skills with 0 APs should NOT appear as roll options.
+ * R9. The roll button tooltip should indicate what can be rolled.
+ * R10. The "Always Substitute" (italicized) checkbox should be visible in
+ *      gadget edit mode and persist when toggled.
+ * R11. A gadget macro (item.roll()) should trigger the roll flow, not just
+ *      post description text.
+ * R12. Chat messages from gadget rolls should identify both the gadget and
+ *      the specific ability rolled.
+ *
+ * Preconditions:
+ * - Foundry VTT running at the configured baseURL with a MEGS world loaded
+ * - Logged in as Gamemaster
+ */
+
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    createHeroActor,
+    addGadgetToActor,
+    addPowerToActor,
+    addSkillToActor,
+    deleteActor,
+    openActorSheet,
+    openItemSheet,
+    closeAllWindows,
+    prefixName,
+} from '../fixtures/test-data.mjs';
+import {
+    isRollDialogOpen,
+    waitForRollDialog,
+    getRollDialogValues,
+    closeRollDialog,
+    submitRollDialog,
+    isPickerDialogOpen,
+    getPickerOptions,
+    cancelPickerDialog,
+    selectPickerOptionAndRoll,
+    getChatMessageCount,
+    getLatestChatMessage,
+} from '../fixtures/roll-helpers.mjs';
+
+// ============================================================
+// Local helpers — gadget-specific, not in shared modules
+// ============================================================
+
+/**
+ * Get names of gadgets that have a roll button visible.
+ */
+async function getRollableGadgetNames(page) {
+    return page.$$eval(
+        '.sheet.actor .tab.gadgets .item-row',
+        (rows) => rows
+            .filter(row => row.querySelector('.d10.rollable'))
+            .map(row => row.querySelector('.item-name a.item-edit.bold')?.textContent?.trim() || '')
+    );
+}
+
+/**
+ * Get names of gadgets that do NOT have a roll button.
+ */
+async function getNonRollableGadgetNames(page) {
+    return page.$$eval(
+        '.sheet.actor .tab.gadgets .item-row',
+        (rows) => rows
+            .filter(row => !row.querySelector('.d10.rollable'))
+            .map(row => row.querySelector('.item-name a.item-edit.bold')?.textContent?.trim() || '')
+    );
+}
+
+/**
+ * Click the roll button for a specific gadget by name.
+ */
+async function clickGadgetRollButton(page, gadgetName) {
+    const clicked = await page.evaluate((name) => {
+        const rows = document.querySelectorAll('.sheet.actor .tab.gadgets .item-row');
+        for (const row of rows) {
+            const nameEl = row.querySelector('.item-name a.item-edit.bold');
+            if (nameEl && nameEl.textContent.trim() === name) {
+                const btn = row.querySelector('.d10.rollable');
+                if (btn) { btn.click(); return true; }
+                return false;
+            }
+        }
+        return false;
+    }, gadgetName);
+    if (!clicked) throw new Error(`Could not click roll button for "${gadgetName}"`);
+    await page.waitForSelector('.dialog', { timeout: 5000 });
+}
+
+/**
+ * Get the tooltip text of a gadget's roll button.
+ */
+async function getGadgetRollTooltip(page, gadgetName) {
+    return page.evaluate((name) => {
+        const rows = document.querySelectorAll('.sheet.actor .tab.gadgets .item-row');
+        for (const row of rows) {
+            const nameEl = row.querySelector('.item-name a.item-edit.bold');
+            if (nameEl && nameEl.textContent.trim() === name) {
+                const btn = row.querySelector('.d10.rollable');
+                return btn?.getAttribute('title') || null;
+            }
+        }
+        return null;
+    }, gadgetName);
+}
+
+// ============================================================
+// TEST SUITE
+// ============================================================
+
+test.describe('Gadget Rolling (#17)', () => {
+
+    // ----------------------------------------------------------
+    // R1 + R5: Rollability — what should and should not roll
+    // ----------------------------------------------------------
+
+    test('R1: Gadget with explicit AV and EV shows roll button', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R1_AVEV'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Blaster', av: 6, ev: 8 });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            const rollable = await getRollableGadgetNames(page);
+            expect(rollable).toContain('Blaster');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R1: Gadget with only EV (no AV) is still rollable', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R1_EVOnly'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Baton', av: 0, ev: 7 });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            const rollable = await getRollableGadgetNames(page);
+            expect(rollable).toContain('Baton');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R2: Gadget with only child powers (APs > 0) is rollable', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R2_Powers'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Visor', av: 0, ev: 0 });
+        await addPowerToActor(page, actorId, {
+            name: 'Energy Blast', aps: 10, link: 'dex', source: 'physical', parent: gadgetId,
+        });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            const rollable = await getRollableGadgetNames(page);
+            expect(rollable).toContain('Visor');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R5: Gadget with no AV/EV, no powers, no skills, no attributes is NOT rollable', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R5_Empty'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Decorative Cape', av: 0, ev: 0 });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            const nonRollable = await getNonRollableGadgetNames(page);
+            expect(nonRollable).toContain('Decorative Cape');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R5/R8: Gadget with only 0-AP skills is NOT rollable', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R5_ZeroSkills'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Toolbox', av: 0, ev: 0 });
+        await addSkillToActor(page, actorId, { name: 'Gadgetry', aps: 0, link: 'int', parent: gadgetId });
+        await addSkillToActor(page, actorId, { name: 'Scientist', aps: 0, link: 'int', parent: gadgetId });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            const nonRollable = await getNonRollableGadgetNames(page);
+            expect(nonRollable).toContain('Toolbox');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R5/R8: Gadget with only 0-AP powers is NOT rollable', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R5_ZeroPowers'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Dead Battery', av: 0, ev: 0 });
+        await addPowerToActor(page, actorId, {
+            name: 'Flight', aps: 0, link: 'dex', source: 'physical', parent: gadgetId,
+        });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            const nonRollable = await getNonRollableGadgetNames(page);
+            expect(nonRollable).toContain('Dead Battery');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R6: Single option -> direct roll dialog, no picker
+    // ----------------------------------------------------------
+
+    test('R6: Single AV/EV option skips picker, opens roll dialog directly', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R6_Single'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Pistol', av: 5, ev: 5 });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            await clickGadgetRollButton(page, 'Pistol');
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(false);
+
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            const values = await getRollDialogValues(page);
+            expect(values.actionValue).toBe(5);
+            expect(values.effectValue).toBe(5);
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R6: Single power option skips picker, opens roll dialog directly', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R6_SinglePower'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Scope', av: 0, ev: 0 });
+        await addPowerToActor(page, actorId, {
+            name: 'Telescopic Vision', aps: 8, link: 'int', source: 'mental', parent: gadgetId,
+        });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            await clickGadgetRollButton(page, 'Scope');
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(false);
+
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            const values = await getRollDialogValues(page);
+            expect(values.actionValue).toBe(8);
+            expect(values.effectValue).toBe(8);
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R7: Multiple options -> picker dialog
+    // ----------------------------------------------------------
+
+    test('R7: Multiple options open picker dialog', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R7_Multi'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Trident', av: 0, ev: 12 });
+        await addPowerToActor(page, actorId, {
+            name: 'Water Control', aps: 10, link: 'int', source: 'mental', parent: gadgetId,
+        });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            await clickGadgetRollButton(page, 'Trident');
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(true);
+
+            const options = await getPickerOptions(page);
+            expect(options).toHaveLength(2);
+            expect(options).toContain('Water Control');
+
+            await cancelPickerDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R7: Picker shows all powers when gadget has many', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R7_ManyPowers'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Power Ring', av: 0, ev: 0 });
+        await addPowerToActor(page, actorId, {
+            name: 'Flight', aps: 20, link: 'dex', source: 'physical', parent: gadgetId,
+        });
+        await addPowerToActor(page, actorId, {
+            name: 'Force Field', aps: 15, link: 'will', source: 'mental', parent: gadgetId,
+        });
+        await addPowerToActor(page, actorId, {
+            name: 'Energy Blast', aps: 18, link: 'dex', source: 'physical', parent: gadgetId,
+        });
+        await addPowerToActor(page, actorId, {
+            name: 'Comprehend Languages', aps: 12, link: 'int', source: 'mental', parent: gadgetId,
+        });
+        await addPowerToActor(page, actorId, {
+            name: 'Life Sense', aps: 25, link: 'int', source: 'mental', parent: gadgetId,
+        });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            await clickGadgetRollButton(page, 'Power Ring');
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(true);
+
+            const options = await getPickerOptions(page);
+            expect(options).toHaveLength(5);
+            expect(options).toContain('Flight');
+            expect(options).toContain('Force Field');
+            expect(options).toContain('Energy Blast');
+            expect(options).toContain('Comprehend Languages');
+            expect(options).toContain('Life Sense');
+
+            await cancelPickerDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R7/R8: Picker excludes 0-AP items, only shows valid options', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R7_Mixed'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Utility Belt', av: 0, ev: 6 });
+        await addPowerToActor(page, actorId, {
+            name: 'Flash', aps: 5, link: 'dex', source: 'physical', parent: gadgetId,
+        });
+        await addPowerToActor(page, actorId, {
+            name: 'Smoke Screen', aps: 0, link: 'dex', source: 'physical', parent: gadgetId,
+        });
+        await addSkillToActor(page, actorId, { name: 'Gadgetry', aps: 0, link: 'int', parent: gadgetId });
+        await addSkillToActor(page, actorId, { name: 'Thief', aps: 4, link: 'dex', parent: gadgetId });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            await clickGadgetRollButton(page, 'Utility Belt');
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(true);
+
+            const options = await getPickerOptions(page);
+            // Should have: AV/EV, Flash, Thief — NOT Smoke Screen (0 AP) or Gadgetry (0 AP)
+            expect(options).toHaveLength(3);
+            expect(options).toContain('Flash');
+            expect(options).toContain('Thief');
+            expect(options).not.toContain('Smoke Screen');
+            expect(options).not.toContain('Gadgetry');
+
+            await cancelPickerDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R7: Canceling picker produces no chat message', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R7_Cancel'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Multi-Weapon', av: 3, ev: 5 });
+        await addPowerToActor(page, actorId, {
+            name: 'Projectile', aps: 7, link: 'dex', source: 'physical', parent: gadgetId,
+        });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            const beforeCount = await getChatMessageCount(page);
+
+            await clickGadgetRollButton(page, 'Multi-Weapon');
+            expect(await isPickerDialogOpen(page)).toBe(true);
+
+            await cancelPickerDialog(page);
+
+            const afterCount = await getChatMessageCount(page);
+            expect(afterCount).toBe(beforeCount);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R9: Tooltip on roll button
+    // ----------------------------------------------------------
+
+    test('R9: Single-option gadget tooltip shows the one option', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R9_Single'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Knife', av: 3, ev: 4 });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            const tooltip = await getGadgetRollTooltip(page, 'Knife');
+            expect(tooltip).not.toBeNull();
+            expect(tooltip.length).toBeGreaterThan(0);
+            // Should contain the gadget name
+            expect(tooltip).toContain('Knife');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R9: Multi-option gadget tooltip lists all options', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R9_Multi'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Staff', av: 0, ev: 0 });
+        await addPowerToActor(page, actorId, {
+            name: 'Lightning', aps: 8, link: 'dex', source: 'physical', parent: gadgetId,
+        });
+        await addPowerToActor(page, actorId, {
+            name: 'Force Bolt', aps: 6, link: 'will', source: 'mental', parent: gadgetId,
+        });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            const tooltip = await getGadgetRollTooltip(page, 'Staff');
+            expect(tooltip).not.toBeNull();
+            expect(tooltip).toContain('Lightning');
+            expect(tooltip).toContain('Force Bolt');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R10: AlwaysSubstitute UI
+    // ----------------------------------------------------------
+
+    test('R10: AlwaysSubstitute checkbox visible in gadget edit mode', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R10_Italic'));
+        const gadgetId = await addGadgetToActor(page, actorId, {
+            name: 'Power Suit', av: 0, ev: 0, attrs: { dex: 8, str: 10 },
+        });
+        try {
+            // Open the gadget's own item sheet
+            await openItemSheet(page, actorId, gadgetId);
+
+            await page.waitForSelector('.sheet.item .always-substitute-label input[type="checkbox"]', { timeout: 5000 });
+
+            // Verify checkboxes exist for always-substitute
+            const checkboxCount = await page.$$eval(
+                '.sheet.item .always-substitute-label input[type="checkbox"]',
+                (cbs) => cbs.length
+            );
+            expect(checkboxCount).toBeGreaterThan(0);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R10: Toggling AlwaysSubstitute persists after closing and reopening sheet', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R10_Persist'));
+        const gadgetId = await addGadgetToActor(page, actorId, {
+            name: 'Armor', av: 0, ev: 0, attrs: { dex: 8, str: 10 },
+        });
+        try {
+            // Open the gadget sheet
+            await openItemSheet(page, actorId, gadgetId);
+
+            await page.waitForSelector('.sheet.item .always-substitute-label input[type="checkbox"]', { timeout: 5000 });
+
+            // Verify DEX checkbox starts unchecked
+            const initialState = await page.$$eval(
+                '.sheet.item .always-substitute-label input[type="checkbox"]',
+                (cbs) => cbs.map(cb => cb.checked)
+            );
+            expect(initialState[0]).toBe(false);
+
+            // Click the DEX always-substitute checkbox and wait for Foundry to persist
+            await page.evaluate(() => {
+                const cbs = document.querySelectorAll('.sheet.item .always-substitute-label input[type="checkbox"]');
+                if (cbs[0]) cbs[0].click();
+            });
+            await page.waitForFunction(({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor?.items.get(gadgetId);
+                return gadget?.system?.attributes?.dex?.alwaysSubstitute === true;
+            }, { timeout: 5000 }, { actorId, gadgetId });
+
+            // Close all sheets
+            await closeAllWindows(page);
+
+            // Verify data model persisted
+            const persisted = await page.evaluate(({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                return gadget.system.attributes.dex.alwaysSubstitute;
+            }, { actorId, gadgetId });
+            expect(persisted).toBe(true);
+
+            // Reopen the gadget sheet
+            await openItemSheet(page, actorId, gadgetId);
+
+            await page.waitForSelector('.sheet.item .always-substitute-label input[type="checkbox"]', { timeout: 5000 });
+
+            // Verify the checkbox is still checked in the UI
+            const afterReopen = await page.$$eval(
+                '.sheet.item .always-substitute-label input[type="checkbox"]',
+                (cbs) => cbs.map(cb => cb.checked)
+            );
+            expect(afterReopen[0]).toBe(true);
+            // STR should still be unchecked
+            expect(afterReopen[1]).toBe(false);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R11: Macro support (item.roll())
+    // ----------------------------------------------------------
+
+    test('R11: item.roll() on single-option gadget triggers roll flow', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R11_Macro'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Sidearm', av: 4, ev: 6 });
+        try {
+            const beforeCount = await getChatMessageCount(page);
+
+            await page.evaluate(({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                gadget.roll();
+            }, { actorId, gadgetId });
+
+            await waitForRollDialog(page);
+
+            // Should open the roll dialog (single option, no picker)
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            await submitRollDialog(page, beforeCount);
+
+            const afterCount = await getChatMessageCount(page);
+            expect(afterCount).toBeGreaterThan(beforeCount);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R11: item.roll() on multi-option gadget shows picker', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R11_MacroPicker'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Combo Weapon', av: 3, ev: 5 });
+        await addPowerToActor(page, actorId, {
+            name: 'Flame Proj', aps: 7, link: 'dex', source: 'physical', parent: gadgetId,
+        });
+        try {
+            await page.evaluate(({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                gadget.roll();
+            }, { actorId, gadgetId });
+
+            await page.waitForSelector('.dialog', { timeout: 5000 });
+
+            const pickerOpen = await isPickerDialogOpen(page);
+            expect(pickerOpen).toBe(true);
+
+            await cancelPickerDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('R11: item.roll() on non-rollable gadget posts description to chat', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R11_NoRoll'));
+        const gadgetId = await addGadgetToActor(page, actorId, {
+            name: 'Trophy', av: 0, ev: 0, description: 'A decorative trophy.',
+        });
+        try {
+            const beforeCount = await getChatMessageCount(page);
+
+            await page.evaluate(({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                gadget.roll();
+            }, { actorId, gadgetId });
+
+            // Wait for chat message to appear
+            await page.waitForFunction(
+                (before) => document.querySelectorAll('#chat-log .chat-message').length > before,
+                { timeout: 5000 },
+                beforeCount
+            );
+
+            // No picker, no roll dialog
+            expect(await isPickerDialogOpen(page)).toBe(false);
+            expect(await isRollDialogOpen(page)).toBe(false);
+
+            // But a chat message should have been posted (description)
+            const afterCount = await getChatMessageCount(page);
+            expect(afterCount).toBeGreaterThan(beforeCount);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R12: Chat message labels
+    // ----------------------------------------------------------
+
+    test('R12: Chat message from gadget roll includes gadget name', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_R12_Label'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Laser Rifle', av: 7, ev: 9 });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            const beforeCount = await getChatMessageCount(page);
+            await clickGadgetRollButton(page, 'Laser Rifle');
+
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            await submitRollDialog(page, beforeCount);
+
+            const latestMsg = await getLatestChatMessage(page);
+            expect(latestMsg).not.toBeNull();
+            // Header should mention the gadget name
+            expect(latestMsg.header).toContain('Laser Rifle');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // Edge cases
+    // ----------------------------------------------------------
+
+    test('EDGE: Gadget with EV but 0 AV derives AV and still rolls correctly', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_EDGE_ZeroAV'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Club', av: 0, ev: 9 });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+            await clickGadgetRollButton(page, 'Club');
+
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            const values = await getRollDialogValues(page);
+            expect(values.effectValue).toBe(9);
+            // AV should be derived (not left at 0) — exact value depends on actor/gadget
+            // At minimum it should be populated
+            expect(values.actionValue).not.toBeNull();
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('EDGE: Actor with multiple gadgets shows correct rollability for each', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_EDGE_MultiGadget'));
+        const weaponId = await addGadgetToActor(page, actorId, { name: 'Weapon A', av: 5, ev: 8 });
+        const ornamentId = await addGadgetToActor(page, actorId, { name: 'Ornament', av: 0, ev: 0 });
+        const scannerId = await addGadgetToActor(page, actorId, { name: 'Scanner', av: 0, ev: 0 });
+        await addPowerToActor(page, actorId, {
+            name: 'Detect', aps: 6, link: 'int', source: 'mental', parent: scannerId,
+        });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+
+            const rollable = await getRollableGadgetNames(page);
+            const nonRollable = await getNonRollableGadgetNames(page);
+
+            expect(rollable).toContain('Weapon A');
+            expect(rollable).toContain('Scanner');
+            expect(nonRollable).toContain('Ornament');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    test('EDGE: Selecting different picker options produces correct AV/EV', async ({ page }) => {
+        const actorId = await createHeroActor(page, prefixName('GadgetTest_EDGE_PickerVals'));
+        const gadgetId = await addGadgetToActor(page, actorId, { name: 'Versatile Weapon', av: 4, ev: 6 });
+        await addPowerToActor(page, actorId, {
+            name: 'Flame Jet', aps: 10, link: 'dex', source: 'physical', parent: gadgetId,
+        });
+        try {
+            await openActorSheet(page, actorId, 'gadgets');
+
+            // First: select the power option (index 1 — powers come after AV/EV)
+            await clickGadgetRollButton(page, 'Versatile Weapon');
+            expect(await isPickerDialogOpen(page)).toBe(true);
+
+            const options = await getPickerOptions(page);
+            expect(options).toHaveLength(2);
+
+            // Select the power (second option)
+            await selectPickerOptionAndRoll(page, 1);
+
+            const rollOpen = await isRollDialogOpen(page);
+            expect(rollOpen).toBe(true);
+
+            const powerValues = await getRollDialogValues(page);
+            // Power AV=EV=APs=10
+            expect(powerValues.actionValue).toBe(10);
+            expect(powerValues.effectValue).toBe(10);
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+});

--- a/e2e/tests/gadget-rolling.spec.mjs
+++ b/e2e/tests/gadget-rolling.spec.mjs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * E2E tests for Issue #17: Gadgets - Rolling
  *
  * These tests verify the REQUIREMENTS for gadget rolling behavior per MEGS RPG
@@ -60,7 +60,7 @@ import {
 } from '../fixtures/roll-helpers.mjs';
 
 // ============================================================
-// Local helpers — gadget-specific, not in shared modules
+// Local helpers â€” gadget-specific, not in shared modules
 // ============================================================
 
 /**
@@ -131,7 +131,7 @@ async function getGadgetRollTooltip(page, gadgetName) {
 test.describe('Gadget Rolling (#17)', () => {
 
     // ----------------------------------------------------------
-    // R1 + R5: Rollability — what should and should not roll
+    // R1 + R5: Rollability â€” what should and should not roll
     // ----------------------------------------------------------
 
     test('R1: Gadget with explicit AV and EV shows roll button', async ({ page }) => {
@@ -362,7 +362,7 @@ test.describe('Gadget Rolling (#17)', () => {
             expect(pickerOpen).toBe(true);
 
             const options = await getPickerOptions(page);
-            // Should have: AV/EV, Flash, Thief — NOT Smoke Screen (0 AP) or Gadgetry (0 AP)
+            // Should have: AV/EV, Flash, Thief â€” NOT Smoke Screen (0 AP) or Gadgetry (0 AP)
             expect(options).toHaveLength(3);
             expect(options).toContain('Flash');
             expect(options).toContain('Thief');
@@ -453,11 +453,11 @@ test.describe('Gadget Rolling (#17)', () => {
             // Open the gadget's own item sheet
             await openItemSheet(page, actorId, gadgetId);
 
-            await page.waitForSelector('.sheet.item .always-substitute-label input[type="checkbox"]', { timeout: 5000 });
+            await page.waitForSelector('.sheet.item .always-substitute-checkbox', { timeout: 5000 });
 
             // Verify checkboxes exist for always-substitute
             const checkboxCount = await page.$$eval(
-                '.sheet.item .always-substitute-label input[type="checkbox"]',
+                '.sheet.item .always-substitute-checkbox',
                 (cbs) => cbs.length
             );
             expect(checkboxCount).toBeGreaterThan(0);
@@ -476,25 +476,25 @@ test.describe('Gadget Rolling (#17)', () => {
             // Open the gadget sheet
             await openItemSheet(page, actorId, gadgetId);
 
-            await page.waitForSelector('.sheet.item .always-substitute-label input[type="checkbox"]', { timeout: 5000 });
+            await page.waitForSelector('.sheet.item .always-substitute-checkbox', { timeout: 5000 });
 
             // Verify DEX checkbox starts unchecked
             const initialState = await page.$$eval(
-                '.sheet.item .always-substitute-label input[type="checkbox"]',
+                '.sheet.item .always-substitute-checkbox',
                 (cbs) => cbs.map(cb => cb.checked)
             );
             expect(initialState[0]).toBe(false);
 
             // Click the DEX always-substitute checkbox and wait for Foundry to persist
             await page.evaluate(() => {
-                const cbs = document.querySelectorAll('.sheet.item .always-substitute-label input[type="checkbox"]');
+                const cbs = document.querySelectorAll('.sheet.item .always-substitute-checkbox');
                 if (cbs[0]) cbs[0].click();
             });
             await page.waitForFunction(({ actorId, gadgetId }) => {
                 const actor = game.actors.get(actorId);
                 const gadget = actor?.items.get(gadgetId);
                 return gadget?.system?.attributes?.dex?.alwaysSubstitute === true;
-            }, { timeout: 5000 }, { actorId, gadgetId });
+            }, { actorId, gadgetId }, { timeout: 5000 });
 
             // Close all sheets
             await closeAllWindows(page);
@@ -510,11 +510,11 @@ test.describe('Gadget Rolling (#17)', () => {
             // Reopen the gadget sheet
             await openItemSheet(page, actorId, gadgetId);
 
-            await page.waitForSelector('.sheet.item .always-substitute-label input[type="checkbox"]', { timeout: 5000 });
+            await page.waitForSelector('.sheet.item .always-substitute-checkbox', { timeout: 5000 });
 
             // Verify the checkbox is still checked in the UI
             const afterReopen = await page.$$eval(
-                '.sheet.item .always-substitute-label input[type="checkbox"]',
+                '.sheet.item .always-substitute-checkbox',
                 (cbs) => cbs.map(cb => cb.checked)
             );
             expect(afterReopen[0]).toBe(true);
@@ -599,9 +599,9 @@ test.describe('Gadget Rolling (#17)', () => {
 
             // Wait for chat message to appear
             await page.waitForFunction(
-                (before) => document.querySelectorAll('#chat-log .chat-message').length > before,
-                { timeout: 5000 },
-                beforeCount
+                (before) => document.querySelectorAll('.chat-log .chat-message').length > before,
+                beforeCount,
+                { timeout: 5000 }
             );
 
             // No picker, no roll dialog
@@ -660,7 +660,7 @@ test.describe('Gadget Rolling (#17)', () => {
 
             const values = await getRollDialogValues(page);
             expect(values.effectValue).toBe(9);
-            // AV should be derived (not left at 0) — exact value depends on actor/gadget
+            // AV should be derived (not left at 0) â€” exact value depends on actor/gadget
             // At minimum it should be populated
             expect(values.actionValue).not.toBeNull();
 
@@ -703,7 +703,7 @@ test.describe('Gadget Rolling (#17)', () => {
         try {
             await openActorSheet(page, actorId, 'gadgets');
 
-            // First: select the power option (index 1 — powers come after AV/EV)
+            // First: select the power option (index 1 â€” powers come after AV/EV)
             await clickGadgetRollButton(page, 'Versatile Weapon');
             expect(await isPickerDialogOpen(page)).toBe(true);
 

--- a/e2e/tests/gadget-sheet-rolling.spec.mjs
+++ b/e2e/tests/gadget-sheet-rolling.spec.mjs
@@ -265,7 +265,7 @@ test.describe('Gadget Sheet Rolling (#13)', () => {
                     if (d.querySelector('input[name="selectedOption"]')) return true;
                 }
                 return false;
-            }, { timeout: 5000 });
+            }, null, { timeout: 5000 });
 
             const isPicker = await isPickerDialogOpen(page);
             expect(isPicker).toBe(true);
@@ -361,7 +361,7 @@ test.describe('Gadget Sheet Rolling (#13)', () => {
                     if (d.querySelector('input[name="selectedOption"]')) return true;
                 }
                 return false;
-            }, { timeout: 5000 });
+            }, null, { timeout: 5000 });
 
             const options = await getPickerOptions(page);
             const optionTexts = options.join(' ');

--- a/e2e/tests/gadget-sheet-rolling.spec.mjs
+++ b/e2e/tests/gadget-sheet-rolling.spec.mjs
@@ -1,0 +1,379 @@
+/**
+ * E2E tests for Issue #13: Roll attacks from gadget sheet
+ *
+ * These tests verify that a gadget's item sheet has a roll button that
+ * triggers the full gadget roll flow (picker dialog when multiple options,
+ * direct roll dialog when single option).
+ *
+ * Requirements under test:
+ * R1. A gadget sheet with explicit AV/EV shows a roll button in the header.
+ * R2. A gadget sheet with child powers shows a roll button.
+ * R3. A gadget sheet with attribute pairs shows a roll button.
+ * R4. A gadget sheet with NO rollable options does NOT show a roll button.
+ * R5. Single roll option: clicking roll button opens roll dialog directly.
+ * R6. Multiple roll options: clicking roll button opens picker dialog.
+ * R7. Roll button tooltip indicates available roll options.
+ * R8. Roll from gadget sheet produces a chat message identifying the gadget.
+ * R9. Picker dialog from gadget sheet lists all available options.
+ *
+ * Preconditions:
+ * - Foundry VTT running at http://localhost:30000 with a MEGS world loaded
+ * - Logged in as Gamemaster
+ */
+
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    createHeroActor,
+    addGadgetToActor,
+    addPowerToActor,
+    addSkillToActor,
+    deleteActor,
+    closeAllWindows,
+    prefixName,
+} from '../fixtures/test-data.mjs';
+import {
+    isRollDialogOpen,
+    waitForRollDialog,
+    getRollDialogValues,
+    closeRollDialog,
+    submitRollDialog,
+    isPickerDialogOpen,
+    getPickerOptions,
+    getChatMessageCount,
+    getLatestChatMessage,
+} from '../fixtures/roll-helpers.mjs';
+
+// ============================================================
+// Gadget-sheet-specific helpers (local to this file)
+// ============================================================
+
+/**
+ * Open a gadget's item sheet by its ID on an actor.
+ */
+async function openGadgetSheet(page, actorId, gadgetId) {
+    await page.evaluate(({ actorId, gadgetId }) => {
+        const actor = game.actors.get(actorId);
+        if (!actor) throw new Error('Actor not found: ' + actorId);
+        const gadget = actor.items.get(gadgetId);
+        if (!gadget) throw new Error('Gadget not found: ' + gadgetId);
+        gadget.sheet.render(true);
+    }, { actorId, gadgetId });
+    await page.waitForSelector('.sheet.item', { timeout: 5000 });
+}
+
+/**
+ * Check if the gadget sheet roll button is visible.
+ */
+async function hasGadgetSheetRollButton(page) {
+    return page.evaluate(() => {
+        const btn = document.querySelector('.sheet.item .d10.rollable[data-type="gadget-roll"]');
+        return !!btn;
+    });
+}
+
+/**
+ * Get the tooltip of the gadget sheet roll button.
+ */
+async function getGadgetSheetRollTooltip(page) {
+    return page.evaluate(() => {
+        const btn = document.querySelector('.sheet.item .d10.rollable[data-type="gadget-roll"]');
+        return btn?.getAttribute('title') || null;
+    });
+}
+
+/**
+ * Click the gadget sheet roll button.
+ */
+async function clickGadgetSheetRollButton(page) {
+    const clicked = await page.evaluate(() => {
+        const btn = document.querySelector('.sheet.item .d10.rollable[data-type="gadget-roll"]');
+        if (btn) { btn.click(); return true; }
+        return false;
+    });
+    if (!clicked) throw new Error('Gadget sheet roll button not found');
+}
+
+/**
+ * Update gadget settings (hasAVAndEV, hasPowers, hasSkills, etc.) after creation.
+ * The addGadgetToActor helper does not set these, so they must be patched separately.
+ */
+async function updateGadgetSettings(page, actorId, gadgetId, settings) {
+    await page.evaluate(async ({ actorId, gadgetId, settings }) => {
+        const actor = game.actors.get(actorId);
+        const gadget = actor.items.get(gadgetId);
+        const current = gadget.system.settings ?? {};
+        await gadget.update({ 'system.settings': { ...current, ...settings } });
+    }, { actorId, gadgetId, settings });
+}
+
+// ============================================================
+// TEST SUITE
+// ============================================================
+
+test.describe('Gadget Sheet Rolling (#13)', () => {
+
+    // ----------------------------------------------------------
+    // R1: Roll button on gadget sheet with AV/EV
+    // ----------------------------------------------------------
+    test('R1: Gadget sheet with AV/EV shows roll button', async ({ page }) => {
+        const actorName = prefixName('GdgSheet_R1');
+        const actorId = await createHeroActor(page, actorName);
+        try {
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'TestWeapon', av: 6, ev: 8,
+            });
+            await updateGadgetSettings(page, actorId, gadgetId, {
+                hasAVAndEV: 'true',
+            });
+
+            await openGadgetSheet(page, actorId, gadgetId);
+            const hasBtn = await hasGadgetSheetRollButton(page);
+            expect(hasBtn).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R2: Roll button on gadget sheet with child powers
+    // ----------------------------------------------------------
+    test('R2: Gadget sheet with child power shows roll button', async ({ page }) => {
+        const actorName = prefixName('GdgSheet_R2');
+        const actorId = await createHeroActor(page, actorName);
+        try {
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'TestDevice',
+            });
+            await addPowerToActor(page, actorId, {
+                name: 'EnergyBlast', aps: 8, link: 'dex', source: 'physical',
+                parent: gadgetId,
+            });
+            await updateGadgetSettings(page, actorId, gadgetId, {
+                hasPowers: 'true',
+            });
+
+            await openGadgetSheet(page, actorId, gadgetId);
+            const hasBtn = await hasGadgetSheetRollButton(page);
+            expect(hasBtn).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R3: Roll button on gadget sheet with attributes
+    // ----------------------------------------------------------
+    test('R3: Gadget sheet with DEX/STR attributes shows roll button', async ({ page }) => {
+        const actorName = prefixName('GdgSheet_R3');
+        const actorId = await createHeroActor(page, actorName);
+        try {
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'TestSuit',
+                attrs: { dex: 7, str: 9 },
+                hasAttributes: { physical: 'true', mental: 'false', mystical: 'false' },
+            });
+
+            await openGadgetSheet(page, actorId, gadgetId);
+            const hasBtn = await hasGadgetSheetRollButton(page);
+            expect(hasBtn).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R4: No roll button when no rollable options
+    // ----------------------------------------------------------
+    test('R4: Gadget sheet with no rollable options hides roll button', async ({ page }) => {
+        const actorName = prefixName('GdgSheet_R4');
+        const actorId = await createHeroActor(page, actorName);
+        try {
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'TestContainer',
+                attrs: { body: 5 },
+                hasAttributes: { physical: 'true', mental: 'false', mystical: 'false' },
+            });
+
+            await openGadgetSheet(page, actorId, gadgetId);
+            const hasBtn = await hasGadgetSheetRollButton(page);
+            expect(hasBtn).toBe(false);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R5: Single option goes directly to roll dialog
+    // ----------------------------------------------------------
+    test('R5: Single roll option opens roll dialog directly', async ({ page }) => {
+        const actorName = prefixName('GdgSheet_R5');
+        const actorId = await createHeroActor(page, actorName);
+        try {
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'TestGun', av: 4, ev: 7,
+            });
+            await updateGadgetSettings(page, actorId, gadgetId, {
+                hasAVAndEV: 'true',
+            });
+
+            await openGadgetSheet(page, actorId, gadgetId);
+            await clickGadgetSheetRollButton(page);
+            await waitForRollDialog(page);
+
+            const isRoll = await isRollDialogOpen(page);
+            expect(isRoll).toBe(true);
+
+            const values = await getRollDialogValues(page);
+            expect(values.actionValue).toBe(4);
+            expect(values.effectValue).toBe(7);
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R6: Multiple options open picker dialog
+    // ----------------------------------------------------------
+    test('R6: Multiple roll options opens picker dialog', async ({ page }) => {
+        const actorName = prefixName('GdgSheet_R6');
+        const actorId = await createHeroActor(page, actorName);
+        try {
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'TestMulti', av: 5, ev: 5,
+            });
+            await addPowerToActor(page, actorId, {
+                name: 'HeatVision', aps: 10, link: 'dex', source: 'physical',
+                parent: gadgetId,
+            });
+            await updateGadgetSettings(page, actorId, gadgetId, {
+                hasAVAndEV: 'true',
+                hasPowers: 'true',
+            });
+
+            await openGadgetSheet(page, actorId, gadgetId);
+            await clickGadgetSheetRollButton(page);
+
+            await page.waitForFunction(() => {
+                for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
+                    if (d.querySelector('input[name="selectedOption"]')) return true;
+                }
+                return false;
+            }, { timeout: 5000 });
+
+            const isPicker = await isPickerDialogOpen(page);
+            expect(isPicker).toBe(true);
+
+            const options = await getPickerOptions(page);
+            expect(options.length).toBeGreaterThanOrEqual(2);
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R7: Roll button tooltip shows option info
+    // ----------------------------------------------------------
+    test('R7: Roll button tooltip indicates rollable options', async ({ page }) => {
+        const actorName = prefixName('GdgSheet_R7');
+        const actorId = await createHeroActor(page, actorName);
+        try {
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'TestBlaster', av: 6, ev: 8,
+            });
+            await updateGadgetSettings(page, actorId, gadgetId, {
+                hasAVAndEV: 'true',
+            });
+
+            await openGadgetSheet(page, actorId, gadgetId);
+            const tooltip = await getGadgetSheetRollTooltip(page);
+            expect(tooltip).not.toBeNull();
+            expect(tooltip).toContain('TestBlaster');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R8: Roll from gadget sheet produces chat message
+    // ----------------------------------------------------------
+    test('R8: Rolling from gadget sheet produces chat message with gadget name', async ({ page }) => {
+        const actorName = prefixName('GdgSheet_R8');
+        const actorId = await createHeroActor(page, actorName);
+        try {
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'TestRifle', av: 5, ev: 6,
+            });
+            await updateGadgetSettings(page, actorId, gadgetId, {
+                hasAVAndEV: 'true',
+            });
+
+            await openGadgetSheet(page, actorId, gadgetId);
+            const beforeCount = await getChatMessageCount(page);
+
+            await clickGadgetSheetRollButton(page);
+            await waitForRollDialog(page);
+            await submitRollDialog(page, beforeCount);
+
+            const msg = await getLatestChatMessage(page);
+            expect(msg).not.toBeNull();
+            expect(msg.header).toContain('TestRifle');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+    // ----------------------------------------------------------
+    // R9: Picker options match available gadget abilities
+    // ----------------------------------------------------------
+    test('R9: Picker dialog lists all rollable options from gadget', async ({ page }) => {
+        const actorName = prefixName('GdgSheet_R9');
+        const actorId = await createHeroActor(page, actorName);
+        try {
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'TestMultiAbility', av: 3, ev: 3,
+                attrs: { dex: 6, str: 8 },
+                hasAttributes: { physical: 'true', mental: 'false', mystical: 'false' },
+            });
+            await addPowerToActor(page, actorId, {
+                name: 'Flame', aps: 7, link: 'dex', source: 'physical',
+                parent: gadgetId,
+            });
+            await updateGadgetSettings(page, actorId, gadgetId, {
+                hasAVAndEV: 'true',
+                hasPowers: 'true',
+            });
+
+            await openGadgetSheet(page, actorId, gadgetId);
+            await clickGadgetSheetRollButton(page);
+
+            await page.waitForFunction(() => {
+                for (const d of document.querySelectorAll('.dialog .megs-dialog')) {
+                    if (d.querySelector('input[name="selectedOption"]')) return true;
+                }
+                return false;
+            }, { timeout: 5000 });
+
+            const options = await getPickerOptions(page);
+            const optionTexts = options.join(' ');
+
+            // Should have AV/EV option, power option, and attribute pair option
+            expect(options.length).toBeGreaterThanOrEqual(3);
+            expect(optionTexts).toContain('Flame');
+            expect(optionTexts).toContain('DEX/STR');
+        } finally {
+            await closeAllWindows(page);
+            await deleteActor(page, actorId);
+        }
+    });
+
+});

--- a/e2e/tests/hero-point-budget.spec.mjs
+++ b/e2e/tests/hero-point-budget.spec.mjs
@@ -1,0 +1,169 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    addPowerToActor,
+    addSkillToActor,
+    addTraitToActor,
+    addModifierToActorItem,
+    deleteActor,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+/**
+ * Category 8 of #226: Hero Point Budget / Character Cost Calculator.
+ *
+ * Expected costs are hardcoded from assets/data/apCostChart.json:
+ *   aps 2: [2, 2, 3, 4, 5, 6, 7, ...]      aps 3: [3, 4, 6, 8, 10, 12, 14, ...]
+ *   aps 4: [4, 6, 9, 12, 15, 18, 21, ...]  aps 5: [5, 8, 12, 16, 20, 24, 28, ...]
+ * (index = factor cost - 1)
+ *
+ * Default test hero: DEX 5, STR 4, BODY 4, INT 3, WILL 3, MIND 3,
+ * INFL 2, AURA 2, SPIRIT 2. Attribute FCs: action attrs 7, others 6.
+ *   DEX 28 + STR 18 + BODY 18 + INT 14 + WILL 12 + MIND 12
+ *   + INFL 7 + AURA 6 + SPIRIT 6 = 121
+ */
+test.describe('Hero Point Budget (#226 cat 8)', () => {
+    const ATTRIBUTES_COST = 121;
+
+    async function getBudget(page, actorId) {
+        return page.evaluate((id) => {
+            const actor = game.actors.get(id);
+            actor.prepareData();
+            return foundry.utils.deepClone(actor.system.heroPointBudget);
+        }, actorId);
+    }
+
+    test('Attribute costs follow the AP Cost Chart', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Budget_Attrs'));
+            const budget = await getBudget(page, actorId);
+            expect(budget.attributesCost).toBe(ATTRIBUTES_COST);
+            expect(budget.base).toBe(450);
+            expect(budget.totalSpent).toBe(ATTRIBUTES_COST);
+            expect(budget.remaining).toBe(450 - ATTRIBUTES_COST);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Power cost = baseCost + AP chart cost (10 + chart[5 APs][FC 3] = 22)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Budget_Power'));
+            await addPowerToActor(page, actorId, {
+                name: 'Flame Being', aps: 5, baseCost: 10, factorCost: 3,
+            });
+            const budget = await getBudget(page, actorId);
+            expect(budget.powersCost).toBe(22);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Skill cost = baseCost + AP chart cost (0 + chart[3 APs][FC 4] = 8)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Budget_Skill'));
+            await addSkillToActor(page, actorId, {
+                name: 'Artist', aps: 3, baseCost: 0, factorCost: 4,
+            });
+            const budget = await getBudget(page, actorId);
+            expect(budget.skillsCost).toBe(8);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Advantage adds its cost; drawback subtracts', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Budget_Traits'));
+            await addTraitToActor(page, actorId, {
+                name: 'Scholar Trait', type: 'advantage', baseCost: 15,
+            });
+            await addTraitToActor(page, actorId, {
+                name: 'Unlucky Trait', type: 'drawback', baseCost: 10,
+            });
+            const budget = await getBudget(page, actorId);
+            expect(budget.advantagesCost).toBe(15);
+            expect(budget.drawbacks).toBe(-10); // stored under "drawbacks"
+            expect(budget.traitsCost).toBe(5);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Bonus factor cost modifier raises a power\'s cost', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Budget_Bonus'));
+            const powerId = await addPowerToActor(page, actorId, {
+                name: 'Energy Blast Test', aps: 5, baseCost: 10, factorCost: 3,
+            });
+            // FC 3 -> 22 total; bonus +2 makes FC 5 -> 10 + chart[5][FC 5]=20 -> 30
+            await addModifierToActorItem(page, actorId, {
+                name: 'Area Bonus', type: 'bonus', factorCostMod: 2, parent: powerId,
+            });
+            const budget = await getBudget(page, actorId);
+            expect(budget.powersCost).toBe(30);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Limitation factor cost modifier lowers a power\'s cost', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Budget_Limitation'));
+            const powerId = await addPowerToActor(page, actorId, {
+                name: 'Energy Blast Test', aps: 5, baseCost: 10, factorCost: 3,
+            });
+            // FC 3 -> 22 total; limitation -1 makes FC 2 -> 10 + chart[5][FC 2]=8 -> 18
+            await addModifierToActorItem(page, actorId, {
+                name: 'Touch Limitation', type: 'limitation', factorCostMod: -1, parent: powerId,
+            });
+            const budget = await getBudget(page, actorId);
+            expect(budget.powersCost).toBe(18);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Total budget sums attributes and all item categories', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Budget_Total'));
+            await addPowerToActor(page, actorId, {
+                name: 'Flight Test', aps: 5, baseCost: 10, factorCost: 3, // 22
+            });
+            await addSkillToActor(page, actorId, {
+                name: 'Detective Test', aps: 3, baseCost: 0, factorCost: 4, // 8
+            });
+            await addTraitToActor(page, actorId, {
+                name: 'Sharp Eye Trait', type: 'advantage', baseCost: 15, // +15
+            });
+            await addTraitToActor(page, actorId, {
+                name: 'Debt Trait', type: 'drawback', baseCost: 10, // -10
+            });
+
+            const budget = await getBudget(page, actorId);
+            const expectedItems = 22 + 8 + 15 - 10;
+            expect(budget.itemsCost).toBe(expectedItems);
+            expect(budget.totalSpent).toBe(ATTRIBUTES_COST + expectedItems);
+            expect(budget.remaining).toBe(450 - ATTRIBUTES_COST - expectedItems);
+            // Internal consistency: components add up to the reported total
+            expect(budget.attributesCost + budget.wealthCost + budget.itemsCost).toBe(budget.totalSpent);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/item-sheets.spec.mjs
+++ b/e2e/tests/item-sheets.spec.mjs
@@ -1,0 +1,234 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    addPowerToActor,
+    addSkillToActor,
+    addSubskillToActor,
+    addTraitToActor,
+    addModifierToActorItem,
+    addGadgetToActor,
+    deleteActor,
+    openItemSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+/**
+ * Category 4 of #226: Item Sheets.
+ * Every MEGS item type opens its sheet and renders its key fields.
+ */
+test.describe('Item Sheets (#226 cat 4)', () => {
+    /** Read a sheet field that may render as an input (edit mode) or plain text. */
+    async function readField(page, selector) {
+        return page.evaluate((sel) => {
+            const el = document.querySelector(sel);
+            if (!el) return null;
+            if (el.tagName === 'INPUT' || el.tagName === 'SELECT') return el.value;
+            return el.textContent.trim();
+        }, selector);
+    }
+
+    /** Force the item sheet into view mode (edit-mode off) before opening. */
+    async function setViewMode(page, actorId, itemId) {
+        await page.evaluate(async ({ actorId, itemId }) => {
+            const item = game.actors.get(actorId).items.get(itemId);
+            item.sheet; // eslint-disable-line no-unused-expressions -- construct first; constructor resets the flag
+            await item.setFlag('megs', 'edit-mode', false);
+        }, { actorId, itemId });
+    }
+
+    test('Power sheet displays APs, base cost, factor cost, and linked attribute', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ItemSheet_Power'));
+            const itemId = await addPowerToActor(page, actorId, {
+                name: 'Heat Vision', aps: 6, baseCost: 10, factorCost: 3, link: 'int',
+            });
+            await setViewMode(page, actorId, itemId);
+            await openItemSheet(page, actorId, itemId);
+
+            expect(await readField(page, '.sheet.item #apsInput')).toBe('6');
+
+            const header = await page.evaluate(() => {
+                const sheet = document.querySelector('.sheet.item');
+                const labels = [...sheet.querySelectorAll('.resource-label')].map(l => l.textContent.trim());
+                return { labels, text: sheet.textContent };
+            });
+            expect(header.labels).toContain('Base');
+            expect(header.labels).toContain('Factor');
+            expect(header.labels).toContain('APs');
+
+            // Base cost 10 shown under the Base label (view mode)
+            const baseCost = await page.evaluate(() => {
+                const label = [...document.querySelectorAll('.sheet.item .resource-label')]
+                    .find(l => l.textContent.trim() === 'Base');
+                return label?.parentElement.querySelector('div')?.textContent.trim() ?? null;
+            });
+            expect(baseCost).toBe('10');
+
+            // Linked attribute displayed on characteristics tab
+            const tabText = await page.evaluate(() => {
+                return document.querySelector('.sheet.item .tab[data-tab="characteristics"]')?.textContent ?? '';
+            });
+            expect(tabText).toContain('Link');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Skill sheet displays APs and has subskills tab', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ItemSheet_Skill'));
+            const itemId = await addSkillToActor(page, actorId, {
+                name: 'Acrobatics', aps: 4, factorCost: 4, link: 'dex',
+            });
+            await setViewMode(page, actorId, itemId);
+            await openItemSheet(page, actorId, itemId);
+
+            expect(await readField(page, '.sheet.item #apsInput')).toBe('4');
+
+            const tabs = await page.evaluate(() =>
+                [...document.querySelectorAll('.sheet.item nav.sheet-tabs .item')].map(a => a.dataset.tab));
+            expect(tabs).toContain('characteristics');
+            expect(tabs).toContain('subskills');
+            expect(tabs).toContain('description');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Subskill sheet opens and renders under its parent skill', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ItemSheet_Subskill'));
+            const skillId = await addSkillToActor(page, actorId, {
+                name: 'Vehicles', aps: 3, factorCost: 3, link: 'dex',
+            });
+            const subskillId = await addSubskillToActor(page, actorId, {
+                name: 'Land Vehicles', aps: 3, parent: skillId, linkedSkill: 'Vehicles',
+            });
+            await openItemSheet(page, actorId, subskillId);
+
+            const rendered = await page.evaluate(() => {
+                const sheet = document.querySelector('.sheet.item');
+                return sheet ? sheet.textContent.includes('Land Vehicles') : false;
+            });
+            expect(rendered).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Advantage sheet displays initial cost', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ItemSheet_Adv'));
+            const itemId = await addTraitToActor(page, actorId, {
+                name: 'Iron Nerves', type: 'advantage', baseCost: 10,
+            });
+            await setViewMode(page, actorId, itemId);
+            await openItemSheet(page, actorId, itemId);
+
+            const text = await page.evaluate(() =>
+                document.querySelector('.sheet.item')?.textContent ?? '');
+            expect(text).toContain('Iron Nerves');
+            expect(text).toContain('Initial Cost');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Drawback sheet displays initial bonus', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ItemSheet_Draw'));
+            const itemId = await addTraitToActor(page, actorId, {
+                name: 'Uncertainty', type: 'drawback', baseCost: 10,
+            });
+            await setViewMode(page, actorId, itemId);
+            await openItemSheet(page, actorId, itemId);
+
+            const text = await page.evaluate(() =>
+                document.querySelector('.sheet.item')?.textContent ?? '');
+            expect(text).toContain('Uncertainty');
+            expect(text).toContain('Initial Bonus');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Bonus sheet displays factor cost modifier', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ItemSheet_Bonus'));
+            const powerId = await addPowerToActor(page, actorId, {
+                name: 'Flame Project', aps: 5, factorCost: 3,
+            });
+            const bonusId = await addModifierToActorItem(page, actorId, {
+                name: 'Area Effect', type: 'bonus', factorCostMod: 2, parent: powerId,
+            });
+            await openItemSheet(page, actorId, bonusId);
+
+            expect(await readField(page, '.sheet.item input[name="system.factorCostMod"]')).toBe('2');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Limitation sheet displays factor cost modifier', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ItemSheet_Lim'));
+            const powerId = await addPowerToActor(page, actorId, {
+                name: 'Ice Production', aps: 5, factorCost: 3,
+            });
+            const limId = await addModifierToActorItem(page, actorId, {
+                name: 'Touch Only', type: 'limitation', factorCostMod: -1, parent: powerId,
+            });
+            await openItemSheet(page, actorId, limId);
+
+            expect(await readField(page, '.sheet.item input[name="system.factorCostMod"]')).toBe('-1');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Gadget sheet opens and renders abilities and description tabs', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ItemSheet_Gadget'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Utility Belt', av: 4, ev: 4,
+            });
+            await openItemSheet(page, actorId, gadgetId);
+
+            const tabs = await page.evaluate(() =>
+                [...document.querySelectorAll('.sheet.item nav.sheet-tabs .item')].map(a => a.dataset.tab));
+            expect(tabs).toContain('abilities');
+            expect(tabs).toContain('description');
+
+            for (const tab of ['abilities', 'description']) {
+                await page.click(`.sheet.item nav.sheet-tabs .item[data-tab="${tab}"]`);
+                await page.waitForFunction(
+                    (t) => {
+                        const el = document.querySelector(`.sheet.item .tab[data-tab="${t}"]`);
+                        return el && el.classList.contains('active');
+                    },
+                    tab,
+                    { timeout: 5000 }
+                );
+            }
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/power-roll-sources.spec.mjs
+++ b/e2e/tests/power-roll-sources.spec.mjs
@@ -23,27 +23,18 @@ async function hasPowerSourceOverrides(page, actorId, powerId) {
 test.describe('Power Roll Sources (#56)', () => {
     let actorId, targetId;
 
-    test.beforeAll(async ({ browser }) => {
-        const page = await browser.newPage();
-        await page.goto('/game');
-        await page.waitForFunction(() => typeof game !== 'undefined' && game.ready === true, { timeout: 30_000 });
-
-        actorId = await createHeroActor(page, prefixName('PowerSrc_Actor'), {
+    test.beforeAll(async ({ workerPage }) => {
+        actorId = await createHeroActor(workerPage, prefixName('PowerSrc_Actor'), {
             dex: 7, str: 5, body: 4, int: 6, will: 3, mind: 3, infl: 4, aura: 2, spirit: 2
         });
-        targetId = await createTargetActor(page, prefixName('PowerSrc_Target'), {
+        targetId = await createTargetActor(workerPage, prefixName('PowerSrc_Target'), {
             dex: 8, str: 6, body: 9, int: 5, will: 4, mind: 7, infl: 3, aura: 3, spirit: 5
         });
-        await page.close();
     });
 
-    test.afterAll(async ({ browser }) => {
-        const page = await browser.newPage();
-        await page.goto('/game');
-        await page.waitForFunction(() => typeof game !== 'undefined' && game.ready === true, { timeout: 30_000 });
-        if (actorId) await deleteActor(page, actorId);
-        if (targetId) await deleteActor(page, targetId);
-        await page.close();
+    test.afterAll(async ({ workerPage }) => {
+        if (actorId) await deleteActor(workerPage, actorId);
+        if (targetId) await deleteActor(workerPage, targetId);
     });
 
     test('R1: Default power uses APs for AV/EV', async ({ page }) => {

--- a/e2e/tests/power-roll-sources.spec.mjs
+++ b/e2e/tests/power-roll-sources.spec.mjs
@@ -1,0 +1,144 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import { prefixName, createHeroActor, createTargetActor, addPowerToActor, deleteActor, closeAllWindows } from '../fixtures/test-data.mjs';
+
+async function resolveRollValues(page, actorId, powerId, targetId) {
+    return page.evaluate(async ({ actorId, powerId, targetId }) => {
+        const { Utils } = await import('/systems/megs/module/utils.js');
+        const actor = game.actors.get(actorId);
+        const power = actor.items.get(powerId);
+        const target = targetId ? game.actors.get(targetId) : null;
+        return Utils.resolvePowerRollValues(power, actor, target);
+    }, { actorId, powerId, targetId });
+}
+
+async function hasPowerSourceOverrides(page, actorId, powerId) {
+    return page.evaluate(async ({ actorId, powerId }) => {
+        const { Utils } = await import('/systems/megs/module/utils.js');
+        const actor = game.actors.get(actorId);
+        const power = actor.items.get(powerId);
+        return Utils.hasPowerSourceOverrides(power);
+    }, { actorId, powerId });
+}
+
+test.describe('Power Roll Sources (#56)', () => {
+    let actorId, targetId;
+
+    test.beforeAll(async ({ browser }) => {
+        const page = await browser.newPage();
+        await page.goto('/game');
+        await page.waitForFunction(() => typeof game !== 'undefined' && game.ready === true, { timeout: 30_000 });
+
+        actorId = await createHeroActor(page, prefixName('PowerSrc_Actor'), {
+            dex: 7, str: 5, body: 4, int: 6, will: 3, mind: 3, infl: 4, aura: 2, spirit: 2
+        });
+        targetId = await createTargetActor(page, prefixName('PowerSrc_Target'), {
+            dex: 8, str: 6, body: 9, int: 5, will: 4, mind: 7, infl: 3, aura: 3, spirit: 5
+        });
+        await page.close();
+    });
+
+    test.afterAll(async ({ browser }) => {
+        const page = await browser.newPage();
+        await page.goto('/game');
+        await page.waitForFunction(() => typeof game !== 'undefined' && game.ready === true, { timeout: 30_000 });
+        if (actorId) await deleteActor(page, actorId);
+        if (targetId) await deleteActor(page, targetId);
+        await page.close();
+    });
+
+    test('R1: Default power uses APs for AV/EV', async ({ page }) => {
+        const powerId = await addPowerToActor(page, actorId, {
+            name: 'DefaultPower', aps: 10, link: 'str', source: 'physical'
+        });
+        const hasOverrides = await hasPowerSourceOverrides(page, actorId, powerId);
+        const resolved = await resolveRollValues(page, actorId, powerId, targetId);
+        expect(hasOverrides).toBe(false);
+        expect(resolved.av).toBe(10);
+        expect(resolved.ev).toBe(10);
+    });
+
+    test('R2: avSource=char:dex uses character DEX as AV', async ({ page }) => {
+        const powerId = await addPowerToActor(page, actorId, {
+            name: 'ClawsPower', aps: 8, link: 'str', source: 'physical',
+            avSource: 'char:dex'
+        });
+        const resolved = await resolveRollValues(page, actorId, powerId, targetId);
+        expect(resolved.av).toBe(7);
+        expect(resolved.ev).toBe(8);
+    });
+
+    test('R3: evSource=char:str uses character STR as EV', async ({ page }) => {
+        const powerId = await addPowerToActor(page, actorId, {
+            name: 'PunchPower', aps: 6, link: 'str', source: 'physical',
+            evSource: 'char:str'
+        });
+        const resolved = await resolveRollValues(page, actorId, powerId, targetId);
+        expect(resolved.av).toBe(6);
+        expect(resolved.ev).toBe(5);
+    });
+
+    test('R4: ovSource=target:int uses target INT as OV', async ({ page }) => {
+        const powerId = await addPowerToActor(page, actorId, {
+            name: 'MindBlast', aps: 9, link: 'int', source: 'mental',
+            ovSource: 'target:int'
+        });
+        const resolved = await resolveRollValues(page, actorId, powerId, targetId);
+        expect(resolved.ov).toBe(5);
+    });
+
+    test('R5: rvSource=target:mind uses target MIND as RV', async ({ page }) => {
+        const powerId = await addPowerToActor(page, actorId, {
+            name: 'Telepathy', aps: 7, link: 'int', source: 'mental',
+            rvSource: 'target:mind'
+        });
+        const resolved = await resolveRollValues(page, actorId, powerId, targetId);
+        expect(resolved.rv).toBe(7);
+    });
+
+    test('R6: All four sources overridden', async ({ page }) => {
+        const powerId = await addPowerToActor(page, actorId, {
+            name: 'FullOverride', aps: 12, link: 'str', source: 'physical',
+            avSource: 'char:dex', evSource: 'char:str',
+            ovSource: 'target:dex', rvSource: 'target:body'
+        });
+        const resolved = await resolveRollValues(page, actorId, powerId, targetId);
+        expect(resolved.av).toBe(7);
+        expect(resolved.ev).toBe(5);
+        expect(resolved.ov).toBe(8);
+        expect(resolved.rv).toBe(9);
+    });
+
+    test('R7: OV/RV with aps source uses power APs', async ({ page }) => {
+        const powerId = await addPowerToActor(page, actorId, {
+            name: 'ApsOvRv', aps: 11, link: 'str', source: 'physical',
+            ovSource: 'aps', rvSource: 'aps'
+        });
+        const resolved = await resolveRollValues(page, actorId, powerId, targetId);
+        expect(resolved.ov).toBe(11);
+        expect(resolved.rv).toBe(11);
+    });
+
+    test('R8: Target sources with no target default to 0', async ({ page }) => {
+        const powerId = await addPowerToActor(page, actorId, {
+            name: 'NoTargetPower', aps: 8, link: 'str', source: 'physical',
+            ovSource: 'target:dex', rvSource: 'target:body'
+        });
+        const resolved = await resolveRollValues(page, actorId, powerId, null);
+        expect(resolved.ov).toBe(0);
+        expect(resolved.rv).toBe(0);
+    });
+
+    test('R9: hasPowerSourceOverrides detects overrides correctly', async ({ page }) => {
+        const defaultPowerId = await addPowerToActor(page, actorId, {
+            name: 'PlainPower', aps: 5, link: 'str', source: 'physical'
+        });
+        const overridePowerId = await addPowerToActor(page, actorId, {
+            name: 'OverridePower', aps: 5, link: 'str', source: 'physical',
+            avSource: 'char:dex'
+        });
+        const noOverrides = await hasPowerSourceOverrides(page, actorId, defaultPowerId);
+        const hasOverrides = await hasPowerSourceOverrides(page, actorId, overridePowerId);
+        expect(noOverrides).toBe(false);
+        expect(hasOverrides).toBe(true);
+    });
+});

--- a/e2e/tests/reliability-number.spec.mjs
+++ b/e2e/tests/reliability-number.spec.mjs
@@ -1,0 +1,165 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    addGadgetToActor,
+    deleteActor,
+    openActorSheet,
+    openItemSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+test.describe('Gadget Reliability Number (#8)', () => {
+    test('Non-zero R# is displayed in gadget description on actor sheet', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Reliability_Show'));
+            await addGadgetToActor(page, actorId, {
+                name: 'Batarang',
+                reliability: 4, // CONFIG.reliabilityScores[4] = 7
+                attrs: { str: 5 },
+            });
+
+            await openActorSheet(page, actorId, 'gadgets');
+
+            // The getGadgetDescription helper renders "R#7" for reliability index 4
+            const descriptionText = await page.evaluate(() => {
+                const descEl = document.querySelector('.sheet.actor .tab.gadgets .item-description');
+                return descEl ? descEl.textContent.trim() : null;
+            });
+
+            expect(descriptionText).not.toBeNull();
+            expect(descriptionText).toContain('R#7');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('R#0 (reliability index 0) is hidden from gadget description', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Reliability_Hide'));
+            await addGadgetToActor(page, actorId, {
+                name: 'Simple Rope',
+                reliability: 0, // CONFIG.reliabilityScores[0] = 0
+                attrs: { str: 3 },
+            });
+
+            await openActorSheet(page, actorId, 'gadgets');
+
+            const descriptionText = await page.evaluate(() => {
+                const descEl = document.querySelector('.sheet.actor .tab.gadgets .item-description');
+                return descEl ? descEl.textContent.trim() : null;
+            });
+
+            expect(descriptionText).not.toBeNull();
+            expect(descriptionText).not.toContain('R#');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Reliability dropdown on gadget sheet has 7 options', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Reliability_Opts'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Gadget With Options',
+                reliability: 3,
+                attrs: { str: 4 },
+            });
+
+            // Set gadget item to edit mode so the dropdown renders
+            await page.evaluate(({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                gadget.setFlag('megs', 'edit-mode', true);
+            }, { actorId, gadgetId });
+
+            await openItemSheet(page, actorId, gadgetId);
+
+            // Navigate to the abilities tab (default tab, but ensure it)
+            await page.waitForSelector('.sheet.item select[name="system.reliability"]', { timeout: 5000 });
+
+            const optionCount = await page.evaluate(() => {
+                const select = document.querySelector('.sheet.item select[name="system.reliability"]');
+                return select ? select.options.length : 0;
+            });
+
+            // CONFIG.reliabilityScores = [0, 2, 3, 5, 7, 9, 11] = 7 entries
+            expect(optionCount).toBe(7);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Changing reliability affects gadget cost calculation', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Reliability_Cost'));
+
+            // Create gadget with reliability index 3 (R#5, modifier 0)
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Cost Test Gadget',
+                reliability: 3, // R#5, modifier 0
+                attrs: { str: 8 },
+            });
+
+            // Read the gadget cost tooltip to understand the cost at R#5
+            const costAtR5 = await page.evaluate(({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                // The getGadgetCostTooltip helper calculates costs
+                // We can use the Handlebars helper directly
+                const helper = Handlebars.helpers.getGadgetCostTooltip;
+                // Build gadget context similar to how the template does
+                const gadgetData = {
+                    ...gadget,
+                    _id: gadget.id,
+                    ownerId: actorId,
+                    system: gadget.system,
+                    name: gadget.name,
+                };
+                return helper(gadgetData);
+            }, { actorId, gadgetId });
+
+            // Now change reliability to index 0 (R#0, modifier +3)
+            await page.evaluate(({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                return gadget.update({ 'system.reliability': 0 });
+            }, { actorId, gadgetId });
+
+            // Wait for update to propagate
+            await page.waitForTimeout(500);
+
+            const costAtR0 = await page.evaluate(({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                const helper = Handlebars.helpers.getGadgetCostTooltip;
+                const gadgetData = {
+                    ...gadget,
+                    _id: gadget.id,
+                    ownerId: actorId,
+                    system: gadget.system,
+                    name: gadget.name,
+                };
+                return helper(gadgetData);
+            }, { actorId, gadgetId });
+
+            // R#0 has modifier +3 (increasing factor costs), so the total cost
+            // should be higher than at R#5 (modifier 0)
+            // Extract "Final Cost: X" from the tooltip text
+            const finalCostR5 = parseInt(costAtR5.match(/Final Cost:\s*(\d+)/)?.[1] || '0');
+            const finalCostR0 = parseInt(costAtR0.match(/Final Cost:\s*(\d+)/)?.[1] || '0');
+
+            expect(finalCostR0).toBeGreaterThan(finalCostR5);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/reliability-number.spec.mjs
+++ b/e2e/tests/reliability-number.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures/foundry-test.mjs';
+﻿import { test, expect } from '../fixtures/foundry-test.mjs';
 import {
     prefixName,
     createHeroActor,
@@ -15,7 +15,7 @@ test.describe('Gadget Reliability Number (#8)', () => {
         try {
             actorId = await createHeroActor(page, prefixName('Reliability_Show'));
             await addGadgetToActor(page, actorId, {
-                name: 'Batarang',
+                name: 'Throwing Blade',
                 reliability: 4, // CONFIG.reliabilityScores[4] = 7
                 attrs: { str: 5 },
             });
@@ -24,7 +24,7 @@ test.describe('Gadget Reliability Number (#8)', () => {
 
             // The getGadgetDescription helper renders "R#7" for reliability index 4
             const descriptionText = await page.evaluate(() => {
-                const descEl = document.querySelector('.sheet.actor .tab.gadgets .item-description');
+                const descEl = document.querySelector('.sheet.actor .tab.gadgets .item-row .item-description');
                 return descEl ? descEl.textContent.trim() : null;
             });
 
@@ -49,7 +49,7 @@ test.describe('Gadget Reliability Number (#8)', () => {
             await openActorSheet(page, actorId, 'gadgets');
 
             const descriptionText = await page.evaluate(() => {
-                const descEl = document.querySelector('.sheet.actor .tab.gadgets .item-description');
+                const descEl = document.querySelector('.sheet.actor .tab.gadgets .item-row .item-description');
                 return descEl ? descEl.textContent.trim() : null;
             });
 
@@ -108,55 +108,59 @@ test.describe('Gadget Reliability Number (#8)', () => {
                 attrs: { str: 8 },
             });
 
-            // Read the gadget cost tooltip to understand the cost at R#5
+            // Expected behavior (3E rules / AP Purchase Chart):
+            //   STR 8 APs @ FC 6                     = 60 HP
+            //   default gadget can be taken away     => ÷4 => 15 HP at R#5 (mod 0)
+            //   R#0 adds +3 to factor costs => FC 9  => 90 HP ÷4 => ceil => 23 HP
             const costAtR5 = await page.evaluate(({ actorId, gadgetId }) => {
-                const actor = game.actors.get(actorId);
-                const gadget = actor.items.get(gadgetId);
-                // The getGadgetCostTooltip helper calculates costs
-                // We can use the Handlebars helper directly
-                const helper = Handlebars.helpers.getGadgetCostTooltip;
-                // Build gadget context similar to how the template does
-                const gadgetData = {
-                    ...gadget,
-                    _id: gadget.id,
-                    ownerId: actorId,
-                    system: gadget.system,
-                    name: gadget.name,
-                };
-                return helper(gadgetData);
+                const gadget = game.actors.get(actorId).items.get(gadgetId);
+                gadget.prepareData();
+                return gadget.system.totalCost;
             }, { actorId, gadgetId });
+            expect(costAtR5).toBe(15);
 
             // Now change reliability to index 0 (R#0, modifier +3)
             await page.evaluate(({ actorId, gadgetId }) => {
-                const actor = game.actors.get(actorId);
-                const gadget = actor.items.get(gadgetId);
+                const gadget = game.actors.get(actorId).items.get(gadgetId);
                 return gadget.update({ 'system.reliability': 0 });
             }, { actorId, gadgetId });
 
-            // Wait for update to propagate
-            await page.waitForTimeout(500);
-
             const costAtR0 = await page.evaluate(({ actorId, gadgetId }) => {
-                const actor = game.actors.get(actorId);
-                const gadget = actor.items.get(gadgetId);
-                const helper = Handlebars.helpers.getGadgetCostTooltip;
-                const gadgetData = {
-                    ...gadget,
-                    _id: gadget.id,
-                    ownerId: actorId,
-                    system: gadget.system,
-                    name: gadget.name,
-                };
-                return helper(gadgetData);
+                const gadget = game.actors.get(actorId).items.get(gadgetId);
+                gadget.prepareData();
+                return gadget.system.totalCost;
+            }, { actorId, gadgetId });
+            expect(costAtR0).toBe(23);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Gadget cost tooltip shows the cost breakdown with final cost', async ({ page }) => {
+        // Expected behavior: the character-creator gadget cost tooltip
+        // breaks down attribute/AV/EV costs and ends with "Final Cost: N".
+        // KNOWN BUG #245: a duplicate getGadgetCostTooltip registration in
+        // megs.mjs replaces the detailed breakdown helper, so the tooltip
+        // renders empty for gadget items. Remove test.fail() with #245.
+        test.fail();
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('Reliability_Tooltip'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Tooltip Test Gadget',
+                reliability: 3, // R#5, modifier 0
+                attrs: { str: 8 },
+            });
+
+            const tooltip = await page.evaluate(({ actorId, gadgetId }) => {
+                const gadget = game.actors.get(actorId).items.get(gadgetId);
+                return Handlebars.helpers.getGadgetCostTooltip(gadget);
             }, { actorId, gadgetId });
 
-            // R#0 has modifier +3 (increasing factor costs), so the total cost
-            // should be higher than at R#5 (modifier 0)
-            // Extract "Final Cost: X" from the tooltip text
-            const finalCostR5 = parseInt(costAtR5.match(/Final Cost:\s*(\d+)/)?.[1] || '0');
-            const finalCostR0 = parseInt(costAtR0.match(/Final Cost:\s*(\d+)/)?.[1] || '0');
-
-            expect(finalCostR0).toBeGreaterThan(finalCostR5);
+            // STR 8 APs @ FC 6 = 60 HP; ÷4 (can be taken away) => 15 HP
+            expect(tooltip).toContain('Attributes: 60');
+            expect(tooltip).toMatch(/Final Cost:\s*15/);
         } finally {
             await closeAllWindows(page);
             if (actorId) await deleteActor(page, actorId);

--- a/e2e/tests/system-init.spec.mjs
+++ b/e2e/tests/system-init.spec.mjs
@@ -1,0 +1,128 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+
+/**
+ * Category 1 of #226: System Initialization.
+ * Verifies the world is running the MEGS system with its data files,
+ * settings, compendium packs, and templates loaded.
+ */
+test.describe('System Initialization (#226 cat 1)', () => {
+    test('World is ready and running the MEGS system', async ({ page }) => {
+        const info = await page.evaluate(() => ({
+            ready: game.ready,
+            systemId: game.system.id,
+            userIsGM: game.user.isGM,
+        }));
+        expect(info.ready).toBe(true);
+        expect(info.systemId).toBe('megs');
+        expect(info.userIsGM).toBe(true);
+    });
+
+    test('System data files are loaded into CONFIG', async ({ page }) => {
+        const config = await page.evaluate(() => ({
+            actionTableRows: CONFIG.tables?.actionTable?.length ?? 0,
+            resultTableRows: CONFIG.tables?.resultTable?.length ?? 0,
+            rangeCount: CONFIG.tables?.ranges?.length ?? 0,
+            maneuvers: CONFIG.combatManeuvers ? Object.keys(CONFIG.combatManeuvers) : [],
+            hasApCostChart: !!CONFIG.apCostChart?.chart,
+        }));
+        expect(config.actionTableRows).toBeGreaterThan(0);
+        expect(config.resultTableRows).toBeGreaterThan(0);
+        expect(config.rangeCount).toBeGreaterThan(0);
+        expect(config.maneuvers).toContain('Critical Blow');
+        expect(config.hasApCostChart).toBe(true);
+    });
+
+    test('System settings are registered and accessible', async ({ page }) => {
+        const settings = await page.evaluate(() => {
+            const keys = [
+                'showHeroPointCosts',
+                'showActiveEffects',
+                'debugLogging',
+                'allowSkillDeletion',
+            ];
+            const out = {};
+            for (const key of keys) {
+                out[key] = {
+                    registered: game.settings.settings.has(`megs.${key}`),
+                    value: game.settings.settings.has(`megs.${key}`)
+                        ? typeof game.settings.get('megs', key)
+                        : null,
+                };
+            }
+            return out;
+        });
+        for (const [key, info] of Object.entries(settings)) {
+            expect(info.registered, `setting megs.${key} registered`).toBe(true);
+            expect(info.value, `setting megs.${key} readable`).toBe('boolean');
+        }
+    });
+
+    test('System compendium packs load correctly', async ({ page }) => {
+        const packs = await page.evaluate(async () => {
+            const names = ['megs.powers', 'megs.advantages', 'megs.drawbacks', 'megs.bonuses', 'megs.limitations'];
+            const out = {};
+            for (const name of names) {
+                const pack = game.packs.get(name);
+                if (!pack) {
+                    out[name] = { exists: false, size: 0 };
+                    continue;
+                }
+                const index = await pack.getIndex();
+                out[name] = { exists: true, size: index.size };
+            }
+            return out;
+        });
+        for (const [name, info] of Object.entries(packs)) {
+            expect(info.exists, `pack ${name} exists`).toBe(true);
+            expect(info.size, `pack ${name} has entries`).toBeGreaterThan(0);
+        }
+    });
+
+    test('Handlebars templates are compiled and registered', async ({ page }) => {
+        const partials = await page.evaluate(() => {
+            const expected = [
+                'systems/megs/templates/actor/parts/actor-attributes.hbs',
+                'systems/megs/templates/actor/parts/actor-header.hbs',
+                'systems/megs/templates/actor/parts/actor-powers.hbs',
+                'systems/megs/templates/actor/parts/actor-skills.hbs',
+                'systems/megs/templates/actor/parts/actor-traits.hbs',
+                'systems/megs/templates/actor/parts/actor-gadgets.hbs',
+            ];
+            return expected.map(path => ({ path, registered: path in Handlebars.partials }));
+        });
+        for (const { path, registered } of partials) {
+            expect(registered, `partial ${path}`).toBe(true);
+        }
+    });
+
+    test('World reloads without MEGS console errors', async ({ page }) => {
+        const errors = [];
+        const onConsole = (msg) => {
+            if (msg.type() === 'error') {
+                errors.push(msg.text());
+            }
+        };
+        const onPageError = (err) => errors.push(String(err.message ?? err));
+        page.on('console', onConsole);
+        page.on('pageerror', onPageError);
+        try {
+            await page.reload({ timeout: 60_000 });
+            await page.waitForFunction(
+                () => typeof game !== 'undefined' && game.ready === true,
+                null,
+                { timeout: 60_000 }
+            );
+        } finally {
+            page.off('console', onConsole);
+            page.off('pageerror', onPageError);
+        }
+
+        // Only fail on errors attributable to the MEGS system, not to
+        // unrelated modules installed in the test world.
+        const megsErrors = errors.filter(text =>
+            /systems\/megs|\[MEGS\]|megs\.mjs|Handlebars/i.test(text) &&
+            !/modules\//.test(text)
+        );
+        expect(megsErrors).toEqual([]);
+    });
+});

--- a/e2e/tests/token-interaction.spec.mjs
+++ b/e2e/tests/token-interaction.spec.mjs
@@ -1,0 +1,191 @@
+/* global canvas, Scene -- Foundry globals used inside page.evaluate callbacks */
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    createTargetActor,
+    openActorSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+import {
+    waitForRollDialog,
+    getRollDialogValues,
+    closeRollDialog,
+    isRollDialogOpen,
+} from '../fixtures/roll-helpers.mjs';
+
+/**
+ * Category 11 of #226: Token Interaction.
+ * A temporary scene with two tokens is created for the whole file and
+ * removed afterwards; the previously viewed scene is restored.
+ */
+test.describe('Token Interaction (#226 cat 11)', () => {
+    let attackerId;
+    let targetId;
+    let sceneId;
+    let originalSceneId;
+
+    test.beforeAll(async ({ workerPage: page }) => {
+        attackerId = await createHeroActor(page, prefixName('Token_Attacker'));
+        // Target defaults: DEX 6, BODY 8 (distinct from attacker's 5/4)
+        targetId = await createTargetActor(page, prefixName('Token_Target'));
+
+        const ids = await page.evaluate(async ({ attackerId, targetId }) => {
+            const originalSceneId = canvas?.scene?.id ?? null;
+            const scene = await Scene.create({
+                name: '_E2E_TokenScene',
+                width: 2000,
+                height: 2000,
+                grid: { size: 100 },
+            });
+            const attacker = game.actors.get(attackerId);
+            const target = game.actors.get(targetId);
+            const attackerToken = (await attacker.getTokenDocument({ x: 500, y: 500 })).toObject();
+            const targetToken = (await target.getTokenDocument({ x: 900, y: 500 })).toObject();
+            await scene.createEmbeddedDocuments('Token', [attackerToken, targetToken]);
+            await scene.view();
+            return { sceneId: scene.id, originalSceneId };
+        }, { attackerId, targetId });
+        sceneId = ids.sceneId;
+        originalSceneId = ids.originalSceneId;
+
+        await page.waitForFunction(
+            (id) => canvas?.ready === true && canvas.scene?.id === id,
+            sceneId,
+            { timeout: 30000 }
+        );
+    });
+
+    test.afterAll(async ({ workerPage: page }) => {
+        await page.evaluate(async ({ sceneId, originalSceneId, attackerId, targetId }) => {
+            for (const t of [...game.user.targets]) {
+                t.setTarget(false, { user: game.user, releaseOthers: false });
+            }
+            if (originalSceneId && game.scenes.get(originalSceneId)) {
+                await game.scenes.get(originalSceneId).view();
+            }
+            const scene = game.scenes.get(sceneId);
+            if (scene) await scene.delete();
+            for (const id of [attackerId, targetId]) {
+                const actor = game.actors.get(id);
+                if (actor) await actor.delete();
+            }
+        }, { sceneId, originalSceneId, attackerId, targetId });
+    });
+
+    /** Find the canvas token for an actor id. */
+    async function getTokenId(page, actorId) {
+        return page.evaluate((id) => {
+            const token = canvas.tokens.placeables.find(t => t.actor?.id === id);
+            return token ? token.id : null;
+        }, actorId);
+    }
+
+    test('Selecting a token controls it on the canvas', async ({ page }) => {
+        const tokenId = await getTokenId(page, attackerId);
+        expect(tokenId).not.toBeNull();
+
+        const controlled = await page.evaluate((tokenId) => {
+            const token = canvas.tokens.get(tokenId);
+            token.control({ releaseOthers: true });
+            return canvas.tokens.controlled.map(t => t.id);
+        }, tokenId);
+        expect(controlled).toEqual([tokenId]);
+    });
+
+    test('Targeting a token feeds its OV/RV into the roll dialog', async ({ page }) => {
+        try {
+            const targetTokenId = await getTokenId(page, targetId);
+            await page.evaluate((tokenId) => {
+                for (const t of [...game.user.targets]) {
+                    t.setTarget(false, { user: game.user, releaseOthers: false });
+                }
+                canvas.tokens.get(tokenId).setTarget(true, { user: game.user, releaseOthers: true });
+            }, targetTokenId);
+
+            const targetCount = await page.evaluate(() => game.user.targets.size);
+            expect(targetCount).toBe(1);
+
+            // DEX roll against the target: OV = target DEX (6), RV = target BODY (8)
+            await openActorSheet(page, attackerId, 'abilities');
+            await page.click('.sheet.actor .tab.abilities .resource-label.rollable[data-key="dex"]');
+            await waitForRollDialog(page);
+
+            const values = await page.evaluate(() => {
+                const d = document.querySelector('.dialog .megs-dialog');
+                return {
+                    ov: Number.parseInt(d.querySelector('#opposingValue').value),
+                    rv: Number.parseInt(d.querySelector('#resistanceValue').value),
+                };
+            });
+            expect(values.ov).toBe(6);
+            expect(values.rv).toBe(8);
+
+            await closeRollDialog(page);
+        } finally {
+            await page.evaluate(() => {
+                for (const t of [...game.user.targets]) {
+                    t.setTarget(false, { user: game.user, releaseOthers: false });
+                }
+            });
+            await closeAllWindows(page);
+        }
+    });
+
+    test('Targeting more than one token warns and blocks the roll', async ({ page }) => {
+        try {
+            const attackerTokenId = await getTokenId(page, attackerId);
+            const targetTokenId = await getTokenId(page, targetId);
+            await page.evaluate(({ a, b }) => {
+                canvas.tokens.get(a).setTarget(true, { user: game.user, releaseOthers: true });
+                canvas.tokens.get(b).setTarget(true, { user: game.user, releaseOthers: false });
+            }, { a: attackerTokenId, b: targetTokenId });
+
+            const targetCount = await page.evaluate(() => game.user.targets.size);
+            expect(targetCount).toBe(2);
+
+            await openActorSheet(page, attackerId, 'abilities');
+            await page.click('.sheet.actor .tab.abilities .resource-label.rollable[data-key="dex"]');
+
+            // Warning notification appears and no roll dialog opens
+            await page.waitForFunction(
+                () => [...document.querySelectorAll('.notification')]
+                    .some(n => n.textContent.includes('You can only target one token')),
+                null,
+                { timeout: 10000 }
+            );
+            expect(await isRollDialogOpen(page)).toBe(false);
+        } finally {
+            await page.evaluate(() => {
+                for (const t of [...game.user.targets]) {
+                    t.setTarget(false, { user: game.user, releaseOthers: false });
+                }
+            });
+            await closeAllWindows(page);
+        }
+    });
+
+    test('Roll from a selected token uses that token\'s actor data', async ({ page }) => {
+        try {
+            const attackerTokenId = await getTokenId(page, attackerId);
+            await page.evaluate((tokenId) => {
+                for (const t of [...game.user.targets]) {
+                    t.setTarget(false, { user: game.user, releaseOthers: false });
+                }
+                canvas.tokens.get(tokenId).control({ releaseOthers: true });
+            }, attackerTokenId);
+
+            // The token's sheet is the actor's sheet: AV should be the
+            // attacker's DEX (5), not the previously targeted actor's.
+            await openActorSheet(page, attackerId, 'abilities');
+            await page.click('.sheet.actor .tab.abilities .resource-label.rollable[data-key="dex"]');
+            await waitForRollDialog(page);
+
+            const values = await getRollDialogValues(page);
+            expect(values.actionValue).toBe(5);
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+        }
+    });
+});

--- a/e2e/tests/trait-drop-blocking.spec.mjs
+++ b/e2e/tests/trait-drop-blocking.spec.mjs
@@ -1,0 +1,201 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    addTraitToActor,
+    deleteActor,
+    openActorSheet,
+    openItemSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+test.describe('Trait Drop Blocking (#178 + #3)', () => {
+    test('gadgetOnly trait is blocked from being added to a hero actor sheet', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('DropBlock_GadgetOnly'));
+
+            // Count items before the drop attempt
+            const beforeCount = await page.evaluate((id) => {
+                return game.actors.get(id).items.size;
+            }, actorId);
+
+            // Simulate _onDropItemCreate with a gadgetOnly advantage
+            const result = await page.evaluate(async (id) => {
+                const actor = game.actors.get(id);
+                const sheet = actor.sheet;
+                const itemData = {
+                    name: 'Gadget Advantage',
+                    type: 'advantage',
+                    system: {
+                        baseCost: 5,
+                        gadgetOnly: true,
+                        creationOnly: false,
+                        text: '',
+                    },
+                };
+                const created = await sheet._onDropItemCreate([itemData]);
+                return created;
+            }, actorId);
+
+            // The blocked drop should return false (no items created)
+            const afterCount = await page.evaluate((id) => {
+                return game.actors.get(id).items.size;
+            }, actorId);
+
+            expect(afterCount).toBe(beforeCount);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('creationOnly trait is blocked from being added to a regular actor sheet', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('DropBlock_Creation'));
+
+            const beforeCount = await page.evaluate((id) => {
+                return game.actors.get(id).items.size;
+            }, actorId);
+
+            // Simulate _onDropItemCreate with a creationOnly advantage
+            await page.evaluate(async (id) => {
+                const actor = game.actors.get(id);
+                const sheet = actor.sheet;
+                const itemData = {
+                    name: 'Creation Advantage',
+                    type: 'advantage',
+                    system: {
+                        baseCost: 5,
+                        gadgetOnly: false,
+                        creationOnly: true,
+                        text: '',
+                    },
+                };
+                await sheet._onDropItemCreate([itemData]);
+            }, actorId);
+
+            const afterCount = await page.evaluate((id) => {
+                return game.actors.get(id).items.size;
+            }, actorId);
+
+            expect(afterCount).toBe(beforeCount);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Normal trait (no flags) is accepted via drop on actor sheet', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('DropBlock_Normal'));
+
+            const beforeCount = await page.evaluate((id) => {
+                return game.actors.get(id).items.size;
+            }, actorId);
+
+            // Simulate _onDropItemCreate with a normal advantage
+            await page.evaluate(async (id) => {
+                const actor = game.actors.get(id);
+                const sheet = actor.sheet;
+                const itemData = {
+                    name: 'Normal Advantage',
+                    type: 'advantage',
+                    system: {
+                        baseCost: 5,
+                        gadgetOnly: false,
+                        creationOnly: false,
+                        text: '',
+                    },
+                };
+                await sheet._onDropItemCreate([itemData]);
+            }, actorId);
+
+            const afterCount = await page.evaluate((id) => {
+                return game.actors.get(id).items.size;
+            }, actorId);
+
+            expect(afterCount).toBe(beforeCount + 1);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('gadgetOnly checkbox is disabled for trait on hero (not in gadget)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('DropBlock_Locked'));
+            const itemId = await addTraitToActor(page, actorId, {
+                name: 'Test Advantage',
+                type: 'advantage',
+                baseCost: 5,
+                gadgetOnly: false,
+            });
+
+            // Ensure edit mode is on for the item
+            await page.evaluate(({ actorId, itemId }) => {
+                const actor = game.actors.get(actorId);
+                const item = actor.items.get(itemId);
+                item.setFlag('megs', 'edit-mode', true);
+            }, { actorId, itemId });
+
+            await openItemSheet(page, actorId, itemId);
+
+            // Navigate to options tab
+            await page.click('.sheet.item .tabs .item[data-tab="options"]');
+            await page.waitForSelector('.sheet.item .tab[data-tab="options"]', { timeout: 5000 });
+
+            // The gadgetOnly checkbox should be disabled because the trait
+            // is on a hero actor (not inside a gadget), which triggers gadgetOnlyLocked
+            const isDisabled = await page.evaluate(() => {
+                const checkbox = document.querySelector('.sheet.item input[name="system.gadgetOnly"]');
+                return checkbox ? checkbox.disabled : null;
+            });
+
+            expect(isDisabled).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('gadgetOnly drawback is also blocked from being added to a hero actor', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('DropBlock_DrawGO'));
+
+            const beforeCount = await page.evaluate((id) => {
+                return game.actors.get(id).items.size;
+            }, actorId);
+
+            // Simulate _onDropItemCreate with a gadgetOnly drawback
+            await page.evaluate(async (id) => {
+                const actor = game.actors.get(id);
+                const sheet = actor.sheet;
+                const itemData = {
+                    name: 'Gadget Drawback',
+                    type: 'drawback',
+                    system: {
+                        baseCost: 5,
+                        gadgetOnly: true,
+                        creationOnly: false,
+                        text: '',
+                    },
+                };
+                await sheet._onDropItemCreate([itemData]);
+            }, actorId);
+
+            const afterCount = await page.evaluate((id) => {
+                return game.actors.get(id).items.size;
+            }, actorId);
+
+            expect(afterCount).toBe(beforeCount);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/trait-subtext.spec.mjs
+++ b/e2e/tests/trait-subtext.spec.mjs
@@ -1,0 +1,183 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    addTraitToActor,
+    deleteActor,
+    openActorSheet,
+    openItemSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+test.describe('Trait Subtext Display (#209)', () => {
+    test('Advantage with subtext shows "Name (Detail)" on actor traits tab', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('TraitSubtext_Adv'));
+            await addTraitToActor(page, actorId, {
+                name: 'Connections',
+                type: 'advantage',
+                baseCost: 5,
+                text: 'Gotham PD',
+            });
+
+            await openActorSheet(page, actorId, 'traits');
+
+            const traitText = await page.evaluate(() => {
+                const rows = document.querySelectorAll('.sheet.actor .tab.traits .item-row');
+                for (const row of rows) {
+                    const nameEl = row.querySelector('.item-name a.item-edit.bold');
+                    if (nameEl && nameEl.textContent.includes('Connections')) {
+                        return nameEl.textContent.trim();
+                    }
+                }
+                return null;
+            });
+
+            expect(traitText).toBe('Connections (Gotham PD)');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Advantage without subtext shows name only (no parentheses)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('TraitSubtext_NoText'));
+            await addTraitToActor(page, actorId, {
+                name: 'Sharp Eye',
+                type: 'advantage',
+                baseCost: 5,
+                text: '',
+            });
+
+            await openActorSheet(page, actorId, 'traits');
+
+            const traitText = await page.evaluate(() => {
+                const rows = document.querySelectorAll('.sheet.actor .tab.traits .item-row');
+                for (const row of rows) {
+                    const nameEl = row.querySelector('.item-name a.item-edit.bold');
+                    if (nameEl && nameEl.textContent.includes('Sharp Eye')) {
+                        return nameEl.textContent.trim();
+                    }
+                }
+                return null;
+            });
+
+            expect(traitText).toBe('Sharp Eye');
+            expect(traitText).not.toContain('(');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Drawback with subtext shows "Name (Detail)" on actor traits tab', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('TraitSubtext_Draw'));
+            await addTraitToActor(page, actorId, {
+                name: 'Dark Secret',
+                type: 'drawback',
+                baseCost: 5,
+                text: 'Criminal Past',
+            });
+
+            await openActorSheet(page, actorId, 'traits');
+
+            const traitText = await page.evaluate(() => {
+                const rows = document.querySelectorAll('.sheet.actor .tab.traits .item-row');
+                for (const row of rows) {
+                    const nameEl = row.querySelector('.item-name a.item-edit.bold');
+                    if (nameEl && nameEl.textContent.includes('Dark Secret')) {
+                        return nameEl.textContent.trim();
+                    }
+                }
+                return null;
+            });
+
+            expect(traitText).toBe('Dark Secret (Criminal Past)');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Item sheet view mode header shows combined "Name (Detail)"', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('TraitSubtext_Sheet'));
+            const itemId = await addTraitToActor(page, actorId, {
+                name: 'Connections',
+                type: 'advantage',
+                baseCost: 5,
+                text: 'Gotham PD',
+            });
+
+            // Ensure the item sheet opens in view mode (edit-mode off)
+            await page.evaluate(({ actorId, itemId }) => {
+                const actor = game.actors.get(actorId);
+                const item = actor.items.get(itemId);
+                item.setFlag('megs', 'edit-mode', false);
+            }, { actorId, itemId });
+
+            await openItemSheet(page, actorId, itemId);
+
+            // In view mode, the header shows: <h1 class="charname isLocked"><div name="name">Name (Detail)</div></h1>
+            const headerText = await page.evaluate(() => {
+                const header = document.querySelector('.sheet.item h1.charname.isLocked div[name="name"]');
+                return header ? header.textContent.trim() : null;
+            });
+
+            expect(headerText).toBe('Connections (Gotham PD)');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Item sheet edit mode shows editable system.text input', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('TraitSubtext_Edit'));
+            const itemId = await addTraitToActor(page, actorId, {
+                name: 'Connections',
+                type: 'advantage',
+                baseCost: 5,
+                text: 'Gotham PD',
+                hasSubtext: true,
+            });
+
+            // Set edit mode on the item
+            await page.evaluate(({ actorId, itemId }) => {
+                const actor = game.actors.get(actorId);
+                const item = actor.items.get(itemId);
+                item.setFlag('megs', 'edit-mode', true);
+            }, { actorId, itemId });
+
+            await openItemSheet(page, actorId, itemId);
+
+            // Wait for the item sheet to re-render in edit mode
+            await page.waitForSelector('.sheet.item input[name="system.text"]', { timeout: 5000 });
+
+            const inputValue = await page.evaluate(() => {
+                const input = document.querySelector('.sheet.item input[name="system.text"]');
+                return input ? input.value : null;
+            });
+
+            expect(inputValue).toBe('Gotham PD');
+
+            // Verify the input is editable (not disabled/readonly)
+            const isEditable = await page.evaluate(() => {
+                const input = document.querySelector('.sheet.item input[name="system.text"]');
+                return input && !input.disabled && !input.readOnly;
+            });
+
+            expect(isEditable).toBe(true);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/e2e/tests/trait-subtext.spec.mjs
+++ b/e2e/tests/trait-subtext.spec.mjs
@@ -115,11 +115,14 @@ test.describe('Trait Subtext Display (#209)', () => {
                 text: 'Gotham PD',
             });
 
-            // Ensure the item sheet opens in view mode (edit-mode off)
-            await page.evaluate(({ actorId, itemId }) => {
+            // Ensure the item sheet opens in view mode (edit-mode off).
+            // Touch item.sheet first: the MEGSItemSheet constructor resets
+            // the edit-mode flag, so the flag must be set after construction.
+            await page.evaluate(async ({ actorId, itemId }) => {
                 const actor = game.actors.get(actorId);
                 const item = actor.items.get(itemId);
-                item.setFlag('megs', 'edit-mode', false);
+                item.sheet; // eslint-disable-line no-unused-expressions
+                await item.setFlag('megs', 'edit-mode', false);
             }, { actorId, itemId });
 
             await openItemSheet(page, actorId, itemId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,10 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.23.2",
+                "@playwright/test": "^1.61.1",
                 "babel-jest": "^27.3.1",
+                "eslint": "^8.57.0",
+                "eslint-config-standard": "^17.1.0",
                 "glob": "^10.3.10",
                 "inquirer": "^9.2.15",
                 "jest": "^29.7.0",
@@ -3802,6 +3805,22 @@
             "optional": true,
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+            "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -12459,6 +12478,53 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "description": "Unofficial Multversal Exponential Game System (MEGS) RPG Support for Foundry VTT",
     "devDependencies": {
         "@babel/preset-env": "^7.23.2",
+        "@playwright/test": "^1.61.1",
         "babel-jest": "^27.3.1",
         "eslint": "^8.57.0",
         "eslint-config-standard": "^17.1.0",
@@ -64,6 +65,7 @@
         "prepare": "git config core.hooksPath scripts/hooks",
         "setup:hooks": "git config core.hooksPath scripts/hooks",
         "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --silent=false",
+        "test:e2e": "npx playwright test --config=playwright.config.mjs",
         "scss": "sass styles/dcc.scss styles/dcc.css"
     },
     "type": "module",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './e2e/tests',
+    timeout: 60_000,
+    expect: { timeout: 10_000 },
+    fullyParallel: false,
+    workers: 1,
+    retries: 0,
+    reporter: 'list',
+    use: {
+        baseURL: 'http://localhost:30000',
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+        actionTimeout: 10_000,
+        navigationTimeout: 15_000,
+    },
+    globalSetup: './e2e/fixtures/global-setup.mjs',
+    projects: [
+        {
+            name: 'chromium',
+            use: {
+                browserName: 'chromium',
+                storageState: './e2e/.auth/state.json',
+            },
+        },
+    ],
+});

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/226-e2e-playwright-test-suite/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/226-e2e-playwright-test-suite/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/226-e2e-playwright-test-suite",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary

- Set up Playwright e2e infrastructure: global login setup, worker-scoped shared page (world loads once per run), serial execution for Foundry VTT's single-connection-per-user model
- Converted 3 existing ad-hoc e2e tests to Playwright: gadget rolling (#17), gadget sheet rolling (#13), power roll sources (#56)
- Added 5 spec files for remaining 1.0.1 features: trait subtext (#209), trait drop blocking (#178, #3), chat message formatting (#93), accordion state persistence (#67), reliability number (#8)
- Added 10 spec files (69 tests) covering the full #226 checklist — **131 tests total**:

| Category | Spec file |
|---|---|
| 1. System initialization | `system-init.spec.mjs` |
| 2–3. Actor sheets (hero/villain/NPC/location/vehicle) | `actor-sheets.spec.mjs` |
| 4. Item sheets (all 8 item types) | `item-sheets.spec.mjs` |
| 5. Drag & drop | `drag-drop.spec.mjs` |
| 6. Dice rolling — action resolution | `action-resolution.spec.mjs` |
| 7. Combat maneuvers | `combat-maneuvers.spec.mjs` |
| 8. Hero point budget | `hero-point-budget.spec.mjs` |
| 9. Gadgets | `gadget-integration.spec.mjs` + existing gadget specs |
| 10. Active effects | `active-effects.spec.mjs` |
| 11. Token interaction | `token-interaction.spec.mjs` |
| 12. Chat messages | `chat-message-formatting.spec.mjs` |

## Key techniques

- **Deterministic dice**: `queueDice()` overrides `Die.prototype.randomFace` (Foundry v13 does not consult `CONFIG.Dice.randomUniform`), so Action Table difficulties, Result Table RAPs, column shifts, double 1s, and doubles rerolls are asserted against exact values hardcoded from `tables.json` / `apCostChart.json`. Dice So Nice is silenced during deterministic rolls.
- **Expected-behavior-first**: tests assert rules-derived values, not current code output. Known product bugs stay asserted at their expected behavior and are annotated `test.fail()` referencing their issues, so the suite is green today and flags loudly when the bugs are fixed: #242 (accordion state) and #245 (gadget cost tooltip clobbered by a duplicate helper registration, found and filed during this work).

## Notes

- Active Effects are covered at the document/API level; the actor sheet has no AE panel yet (prep code is a TODO in `actor-sheet.mjs`).
- Fixture fix: gadget `settings.hasAttributes` is written in the `{physical, mental, mystical}` object shape the templates gate on — this was the real cause of the AlwaysSubstitute R10 test failures.

## Test plan

- [ ] Run `npm install` and `npx playwright install chromium`
- [ ] Start Foundry VTT at localhost:30000 with the MEGS Test World
- [ ] Run `npm run test:e2e` — expect 129 passed + 3 expected failures (`test.fail()` for #242/#245), ~27 min single worker
- [ ] Verify no leftover `_E2E_` actors or scenes remain after the run

Fixes #226