### PR TITLE
Fix duplicate getGadgetCostTooltip helper clobbering gadget cost tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed `ReferenceError` crash when selecting multiple targets — `localize()` replaced with `game.i18n.localize()` (issue #215)
 - Fixed `ReferenceError` in `compare` Handlebars helper — added missing `options` parameter (issue #215)
 - Fixed trailing slash in system.json download URL that prevented Foundry from resolving the package
+- Fixed empty gadget cost tooltip on the character creator sheet — a duplicate `getGadgetCostTooltip` Handlebars registration clobbered the cost-breakdown helper; the raw/adjusted cost helper is now registered as `getGadgetAdjustedCostTooltip` (issue #245)
 
 ### Testing
 

--- a/e2e/tests/reliability-number.spec.mjs
+++ b/e2e/tests/reliability-number.spec.mjs
@@ -138,12 +138,8 @@ test.describe('Gadget Reliability Number (#8)', () => {
     });
 
     test('Gadget cost tooltip shows the cost breakdown with final cost', async ({ page }) => {
-        // Expected behavior: the character-creator gadget cost tooltip
-        // breaks down attribute/AV/EV costs and ends with "Final Cost: N".
-        // KNOWN BUG #245: a duplicate getGadgetCostTooltip registration in
-        // megs.mjs replaces the detailed breakdown helper, so the tooltip
-        // renders empty for gadget items. Remove test.fail() with #245.
-        test.fail();
+        // The character-creator gadget cost tooltip breaks down
+        // attribute/AV/EV costs and ends with "Final Cost: N".
         let actorId;
         try {
             actorId = await createHeroActor(page, prefixName('Reliability_Tooltip'));

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -980,33 +980,24 @@ Handlebars.registerHelper('getGadgetCostTooltip', function (gadget) {
     const reliability = CONFIG.reliabilityScores?.[reliabilityIndex] ?? 5;
     const reliabilityMod = getReliabilityMod(reliability);
 
-    // Debug: Show what reliability value we're reading
-    console.log(`[${gadget.name}] Reliability Index: ${systemData.reliability}, R#: ${reliability}, Mod: ${reliabilityMod}`);
-
     // Calculate attribute costs
     let attributesCost = 0;
     if (systemData.attributes) {
         for (const [key, attr] of Object.entries(systemData.attributes)) {
             if (attr.value > 0) {
                 let fc = attr.factorCost + reliabilityMod;
-                console.log(`  ${key.toUpperCase()}: base FC=${attr.factorCost}, +reliabilityMod(${reliabilityMod})`);
                 if (attr.alwaysSubstitute) {
                     fc += 2;
-                    console.log('    +2 for alwaysSubstitute');
                 }
                 if (key === 'body' && (systemData.hasHardenedDefenses === true || systemData.hasHardenedDefenses === 'true')) {
                     fc += 2;
-                    console.log('    +2 for Hardened Defenses');
                 }
                 fc = Math.max(1, fc);
-                const attrCost = MEGS.getAPCost(attr.value, fc) || 0;
-                console.log(`    Final: ${attr.value} APs @ FC ${fc} = ${attrCost} HP`);
-                attributesCost += attrCost;
+                attributesCost += MEGS.getAPCost(attr.value, fc) || 0;
             }
         }
     }
     if (attributesCost > 0) {
-        console.log(`  Total Attributes: ${attributesCost} HP`);
         tooltip += 'Attributes: ' + attributesCost + '\n';
         totalBeforeBonus += attributesCost;
     }
@@ -1014,9 +1005,7 @@ Handlebars.registerHelper('getGadgetCostTooltip', function (gadget) {
     // Calculate AV cost
     if (systemData.actionValue > 0) {
         const fc = Math.max(1, 1 + reliabilityMod);
-        const chartCost = MEGS.getAPCost(systemData.actionValue, fc) || 0;
-        const avCost = 5 + chartCost;
-        console.log(`  AV: 5 (base) + ${systemData.actionValue} APs @ FC ${fc} = ${chartCost} HP → Total: ${avCost} HP`);
+        const avCost = 5 + (MEGS.getAPCost(systemData.actionValue, fc) || 0);
         tooltip += `AV: ${avCost}\n`;
         totalBeforeBonus += avCost;
     }
@@ -1084,13 +1073,10 @@ Handlebars.registerHelper('getGadgetCostTooltip', function (gadget) {
 
     // Add gadget bonus (divide by 4 if can be Taken Away, 2 if cannot)
     const gadgetBonus = systemData.canBeTakenAway ? 4 : 2;
-    console.log(`  Total before bonus: ${totalBeforeBonus} HP`);
-    console.log(`  Gadget Bonus: ÷${gadgetBonus}`);
     tooltip += 'Gadget Bonus: ÷' + gadgetBonus + '\n';
 
     // Add final cost
     const finalCost = Math.ceil(totalBeforeBonus / gadgetBonus);
-    console.log(`  Final Cost: ${totalBeforeBonus} ÷ ${gadgetBonus} = ${finalCost} HP`);
     tooltip += 'Final Cost: ' + finalCost;
 
     return tooltip;
@@ -1155,9 +1141,9 @@ Handlebars.registerHelper('getGadgetAdjustedCost', function (rawCost, canBeTaken
 });
 
 /**
- * Get tooltip explaining the gadget cost calculation
+ * Get tooltip explaining how a raw cost is adjusted by the Can Be Taken Away divisor
  */
-Handlebars.registerHelper('getGadgetCostTooltip', function (rawCost, canBeTakenAway) {
+Handlebars.registerHelper('getGadgetAdjustedCostTooltip', function (rawCost, canBeTakenAway) {
     const cost = Number(rawCost) || 0;
     if (cost === 0) return '';
 

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/245-duplicate-getgadgetcosttooltip-helper/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/245-duplicate-getgadgetcosttooltip-helper/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/245-duplicate-getgadgetcosttooltip-helper",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,

--- a/templates/item/gadget-builder-sheet.hbs
+++ b/templates/item/gadget-builder-sheet.hbs
@@ -57,14 +57,14 @@
             <section class="attributes-summary">
                 <div class="summary-row">
                     <label class="summary-label">{{localize 'MEGS.TotalAttributesCost'}}</label>
-                    <span class="summary-value cost-tooltip" title="{{getGadgetCostTooltip system.gadgetPointBudget.attributesCost system.canBeTakenAway}}">
+                    <span class="summary-value cost-tooltip" title="{{getGadgetAdjustedCostTooltip system.gadgetPointBudget.attributesCost system.canBeTakenAway}}">
                         {{formatNumber (getGadgetAdjustedCost system.gadgetPointBudget.attributesCost system.canBeTakenAway)}} HP
                     </span>
                 </div>
                 {{#if (compare system.settings.hasAVAndEV "eq" "true")}}
                 <div class="summary-row">
                     <label class="summary-label">{{localize 'MEGS.AVEVCost'}}</label>
-                    <span class="summary-value cost-tooltip" title="{{getGadgetCostTooltip system.gadgetPointBudget.avEvCost system.canBeTakenAway}}">
+                    <span class="summary-value cost-tooltip" title="{{getGadgetAdjustedCostTooltip system.gadgetPointBudget.avEvCost system.canBeTakenAway}}">
                         {{formatNumber (getGadgetAdjustedCost system.gadgetPointBudget.avEvCost system.canBeTakenAway)}} HP
                     </span>
                 </div>
@@ -248,7 +248,7 @@
             <section class="powers-summary">
                 <div class="summary-row">
                     <label class="summary-label">{{localize 'MEGS.TotalPowersCost'}}</label>
-                    <span class="summary-value cost-tooltip" title="{{getGadgetCostTooltip system.gadgetPointBudget.powersCost system.canBeTakenAway}}">
+                    <span class="summary-value cost-tooltip" title="{{getGadgetAdjustedCostTooltip system.gadgetPointBudget.powersCost system.canBeTakenAway}}">
                         {{formatNumber (getGadgetAdjustedCost system.gadgetPointBudget.powersCost system.canBeTakenAway)}} HP
                     </span>
                 </div>
@@ -320,7 +320,7 @@
             <section class="skills-summary">
                 <div class="summary-row">
                     <label class="summary-label">{{localize 'MEGS.TotalSkillsCost'}}</label>
-                    <span class="summary-value cost-tooltip" title="{{getGadgetCostTooltip system.gadgetPointBudget.skillsCost system.canBeTakenAway}}">
+                    <span class="summary-value cost-tooltip" title="{{getGadgetAdjustedCostTooltip system.gadgetPointBudget.skillsCost system.canBeTakenAway}}">
                         {{formatNumber (getGadgetAdjustedCost system.gadgetPointBudget.skillsCost system.canBeTakenAway)}} HP
                     </span>
                 </div>
@@ -359,7 +359,7 @@
             <section class="traits-summary">
                 <div class="summary-row">
                     <label class="summary-label">{{localize 'MEGS.NetTraitsCost'}}</label>
-                    <span class="summary-value cost-tooltip" title="{{getGadgetCostTooltip system.gadgetPointBudget.traitsCost system.canBeTakenAway}}">
+                    <span class="summary-value cost-tooltip" title="{{getGadgetAdjustedCostTooltip system.gadgetPointBudget.traitsCost system.canBeTakenAway}}">
                         {{formatNumber (getGadgetAdjustedCost system.gadgetPointBudget.traitsCost system.canBeTakenAway)}} HP
                     </span>
                 </div>


### PR DESCRIPTION
Fixes #245

## Problem

`module/megs.mjs` registered two Handlebars helpers named `getGadgetCostTooltip` with incompatible signatures:

- **line ~965** — `getGadgetCostTooltip(gadget)`, the detailed cost breakdown (attribute costs with reliability / alwaysSubstitute / hardened-defenses modifiers, AV/EV/range, child item costs, gadget bonus divisor), ending in `Final Cost: N`. Called from `character-creator-sheet.hbs` with a gadget item.
- **line ~1160** — `getGadgetCostTooltip(rawCost, canBeTakenAway)`, which formats a raw cost number as `Raw Cost / Adjusted`. Called from `gadget-builder-sheet.hbs` at 5 sites with numeric budget values.

Handlebars keeps only the last registration, so the numeric helper silently replaced the breakdown helper. The character creator then passed a gadget object into the numeric helper, where `Number(gadget) || 0` evaluated to `0` and early-returned `''` — leaving the gadget cost tooltip blank, with the entire breakdown helper unreachable.

## Fix

Renamed the numeric helper to `getGadgetAdjustedCostTooltip`, matching its existing sibling `getGadgetAdjustedCost(rawCost, canBeTakenAway)`, and updated its 5 call sites in `gadget-builder-sheet.hbs`. Each helper name is now registered exactly once and every call site matches its intended signature.

Also removed the 10 debug `console.log` statements from the breakdown helper. They were dead code while the helper was shadowed; once it becomes reachable they would log on every gadget render.

## Verification

- `e2e/tests/reliability-number.spec.mjs` — "Gadget cost tooltip shows the cost breakdown with final cost" was annotated `test.fail()` for this bug. Confirmed it fails on the base branch for the predicted reason (tooltip is `""`), removed the annotation, and it now passes.
- Full Playwright suite: **130 passed, 2 flaky, 0 failed** (132 tests). Both flaky tests (`active-effects`, `trait-subtext`) passed on retry and are unrelated to this change; the `trait-subtext` intermittency is the `setFlag` race tracked in #243.
- Jest: 74/74 passed.
- Gadget-builder sheet cost tooltips (`Raw Cost / Adjusted`) still render after the rename.