### PR TITLE
Derive sheet edit-mode instead of writing it from the constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed empty gadget cost tooltip on the character creator sheet — a duplicate `getGadgetCostTooltip` Handlebars registration clobbered the cost-breakdown helper; the raw/adjusted cost helper is now registered as `getGadgetAdjustedCostTooltip` (issue #245)
 - Fixed item and actor sheets overwriting the edit-mode flag on every open — the sheet constructors wrote the flag with an un-awaited `setFlag` that raced the first render; the lock state is now derived at render time, so edit/view mode persists per document and no longer flips back to edit mode when a sheet is reopened (issue #243)
 - Fixed the edit-mode toggle negating the stored flag rather than the effective state, and no longer writing the flag for non-owners or compendium documents (issue #243)
+- Fixed the NPC sheet failing to render in edit mode — NPCs had no `system.motivations`, so the motivation `selectOptions` threw `Cannot convert undefined or null to object` and took down the entire sheet render; NPCs now receive the full motivation list (hero, villain, and antihero). This was masked by the edit-mode flag race, which left the first render in view mode (issue #243)
 
 ### Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Fixed `ReferenceError` in `compare` Handlebars helper — added missing `options` parameter (issue #215)
 - Fixed trailing slash in system.json download URL that prevented Foundry from resolving the package
 - Fixed empty gadget cost tooltip on the character creator sheet — a duplicate `getGadgetCostTooltip` Handlebars registration clobbered the cost-breakdown helper; the raw/adjusted cost helper is now registered as `getGadgetAdjustedCostTooltip` (issue #245)
+- Fixed item and actor sheets overwriting the edit-mode flag on every open — the sheet constructors wrote the flag with an un-awaited `setFlag` that raced the first render; the lock state is now derived at render time, so edit/view mode persists per document and no longer flips back to edit mode when a sheet is reopened (issue #243)
+- Fixed the edit-mode toggle negating the stored flag rather than the effective state, and no longer writing the flag for non-owners or compendium documents (issue #243)
 
 ### Testing
 
@@ -36,6 +38,8 @@
 - Configured Playwright with global setup for Foundry login, shared fixtures, and serial execution
 - Converted 3 existing ad-hoc E2E tests to Playwright: gadget rolling (#17), gadget sheet rolling (#13), power roll sources (#56)
 - Added new E2E tests for: trait subtext (#209), trait drop blocking (#178, #3), chat message formatting (#93), accordion state persistence (#67), reliability number (#8)
+- Fixed the `ItemSheet`/`ActorSheet` Jest mocks not setting `this.object`, which left the sheet constructors' flag-writing branch as dead code in every unit test and hid issue #243; added unit coverage for edit-mode derivation and toggling (issue #243)
+- Removed E2E workarounds that constructed a sheet before setting the edit-mode flag, and awaited `setFlag` calls that were previously fire-and-forget (issue #243)
 
 ### Code Quality
 

--- a/e2e/tests/gadget-integration.spec.mjs
+++ b/e2e/tests/gadget-integration.spec.mjs
@@ -108,7 +108,6 @@ test.describe('Gadget Integration (#226 cat 9)', () => {
             // Open in view mode; attribute labels localize to full names
             await page.evaluate(async ({ actorId, itemId }) => {
                 const item = game.actors.get(actorId).items.get(itemId);
-                item.sheet; // eslint-disable-line no-unused-expressions -- construct first; constructor resets the flag
                 await item.setFlag('megs', 'edit-mode', false);
             }, { actorId, itemId: gadgetId });
             await openItemSheet(page, actorId, gadgetId);

--- a/e2e/tests/item-sheets.spec.mjs
+++ b/e2e/tests/item-sheets.spec.mjs
@@ -32,7 +32,6 @@ test.describe('Item Sheets (#226 cat 4)', () => {
     async function setViewMode(page, actorId, itemId) {
         await page.evaluate(async ({ actorId, itemId }) => {
             const item = game.actors.get(actorId).items.get(itemId);
-            item.sheet; // eslint-disable-line no-unused-expressions -- construct first; constructor resets the flag
             await item.setFlag('megs', 'edit-mode', false);
         }, { actorId, itemId });
     }
@@ -226,6 +225,41 @@ test.describe('Item Sheets (#226 cat 4)', () => {
                     { timeout: 5000 }
                 );
             }
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Edit-mode flag set before the sheet is opened survives construction (#243)', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('ItemSheet_EditModeFlag'));
+            const itemId = await addTraitToActor(page, actorId, {
+                name: 'Connections',
+                type: 'advantage',
+                baseCost: 5,
+            });
+
+            // Lock the item without ever constructing its sheet. The sheet used to
+            // overwrite this flag from its constructor, forcing edit mode back on.
+            await page.evaluate(async ({ actorId, itemId }) => {
+                const item = game.actors.get(actorId).items.get(itemId);
+                await item.setFlag('megs', 'edit-mode', false);
+            }, { actorId, itemId });
+
+            await openItemSheet(page, actorId, itemId);
+
+            const storedFlag = await page.evaluate(({ actorId, itemId }) => {
+                return game.actors.get(actorId).items.get(itemId).getFlag('megs', 'edit-mode');
+            }, { actorId, itemId });
+            expect(storedFlag).toBe(false);
+
+            // View mode renders the locked header rather than an editable name input.
+            const isLocked = await page.evaluate(
+                () => !!document.querySelector('.sheet.item h1.charname.isLocked')
+            );
+            expect(isLocked).toBe(true);
         } finally {
             await closeAllWindows(page);
             if (actorId) await deleteActor(page, actorId);

--- a/e2e/tests/reliability-number.spec.mjs
+++ b/e2e/tests/reliability-number.spec.mjs
@@ -72,10 +72,10 @@ test.describe('Gadget Reliability Number (#8)', () => {
             });
 
             // Set gadget item to edit mode so the dropdown renders
-            await page.evaluate(({ actorId, gadgetId }) => {
+            await page.evaluate(async ({ actorId, gadgetId }) => {
                 const actor = game.actors.get(actorId);
                 const gadget = actor.items.get(gadgetId);
-                gadget.setFlag('megs', 'edit-mode', true);
+                await gadget.setFlag('megs', 'edit-mode', true);
             }, { actorId, gadgetId });
 
             await openItemSheet(page, actorId, gadgetId);

--- a/e2e/tests/trait-drop-blocking.spec.mjs
+++ b/e2e/tests/trait-drop-blocking.spec.mjs
@@ -136,10 +136,10 @@ test.describe('Trait Drop Blocking (#178 + #3)', () => {
             });
 
             // Ensure edit mode is on for the item
-            await page.evaluate(({ actorId, itemId }) => {
+            await page.evaluate(async ({ actorId, itemId }) => {
                 const actor = game.actors.get(actorId);
                 const item = actor.items.get(itemId);
-                item.setFlag('megs', 'edit-mode', true);
+                await item.setFlag('megs', 'edit-mode', true);
             }, { actorId, itemId });
 
             await openItemSheet(page, actorId, itemId);

--- a/e2e/tests/trait-subtext.spec.mjs
+++ b/e2e/tests/trait-subtext.spec.mjs
@@ -116,12 +116,9 @@ test.describe('Trait Subtext Display (#209)', () => {
             });
 
             // Ensure the item sheet opens in view mode (edit-mode off).
-            // Touch item.sheet first: the MEGSItemSheet constructor resets
-            // the edit-mode flag, so the flag must be set after construction.
             await page.evaluate(async ({ actorId, itemId }) => {
                 const actor = game.actors.get(actorId);
                 const item = actor.items.get(itemId);
-                item.sheet; // eslint-disable-line no-unused-expressions
                 await item.setFlag('megs', 'edit-mode', false);
             }, { actorId, itemId });
 
@@ -153,10 +150,10 @@ test.describe('Trait Subtext Display (#209)', () => {
             });
 
             // Set edit mode on the item
-            await page.evaluate(({ actorId, itemId }) => {
+            await page.evaluate(async ({ actorId, itemId }) => {
                 const actor = game.actors.get(actorId);
                 const item = actor.items.get(itemId);
-                item.setFlag('megs', 'edit-mode', true);
+                await item.setFlag('megs', 'edit-mode', true);
             }, { actorId, itemId });
 
             await openItemSheet(page, actorId, itemId);

--- a/module/__mocks__/foundry.mjs
+++ b/module/__mocks__/foundry.mjs
@@ -208,6 +208,10 @@ class ActorSheet {
     constructor(data, options) {
         if (data) {
             Object.assign(this, data);
+            // Foundry's DocumentSheet exposes the document as `object`, with
+            // `actor` as an alias. Sheet code relies on both.
+            this.object = data;
+            this.actor = data;
         } else {
             this._id = 1;
             this.name = 'Anonymous Hero';
@@ -229,6 +233,10 @@ class ItemSheet {
     constructor(data, options) {
         if (data) {
             Object.assign(this, data);
+            // Foundry's DocumentSheet exposes the document as `object`, with
+            // `item` as an alias. Sheet code relies on both.
+            this.object = data;
+            this.item = data;
         } else {
             this._id = 1;
         }

--- a/module/__tests__/actor-sheet.test.js
+++ b/module/__tests__/actor-sheet.test.js
@@ -2,10 +2,21 @@
 TODO Test skill roll from actor sheet
 */
 
+import { jest } from '@jest/globals';
 import { MEGSActorSheet } from '../sheets/actor-sheet.mjs';
 
 const actor = { isOwner: true, _stats: { compendiumSource: false }, setFlag: () => {} };
 const actorSheet = new MEGSActorSheet(actor);
+
+/** Build an actor document stand-in with a controllable stored edit-mode flag. */
+function mockDocument({ isOwner = true, compendiumSource = null, storedFlag } = {}) {
+    return {
+        isOwner,
+        _stats: { compendiumSource },
+        getFlag: jest.fn(() => storedFlag),
+        setFlag: jest.fn(),
+    };
+}
 
 test('_hasAbility', () => {
     const powers = [
@@ -46,4 +57,41 @@ test('_getAbilityAPs returns correct APs for power', () => {
     expect(actorSheet._getAbilityAPs(powers, 'Superspeed')).toBe(7);
     expect(actorSheet._getAbilityAPs(powers, 'Flight')).toBe(3);
     expect(actorSheet._getAbilityAPs(powers, 'Invisibility')).toBe(0);
+});
+
+// --- edit-mode (issue #243) ---------------------------------------------------
+
+test('constructor does not write the edit-mode flag', () => {
+    const doc = mockDocument();
+    new MEGSActorSheet(doc, {});
+    // Writing a flag from the constructor races the first render: the render
+    // reads the old value, then the un-awaited write triggers a second render.
+    expect(doc.setFlag).not.toHaveBeenCalled();
+});
+
+test('isEditMode defaults to unlocked for an owner with no stored flag', () => {
+    const sheet = new MEGSActorSheet(mockDocument({ storedFlag: undefined }), {});
+    expect(sheet.isEditMode).toBe(true);
+});
+
+test('isEditMode honours a stored false flag for an owner', () => {
+    const sheet = new MEGSActorSheet(mockDocument({ storedFlag: false }), {});
+    expect(sheet.isEditMode).toBe(false);
+});
+
+test('isEditMode defaults to locked for a non-owner', () => {
+    const sheet = new MEGSActorSheet(mockDocument({ isOwner: false }), {});
+    expect(sheet.isEditMode).toBe(false);
+});
+
+test('_toggleEditMode locks a sheet that is unlocked by default', async () => {
+    const doc = mockDocument({ storedFlag: undefined });
+    const sheet = new MEGSActorSheet(doc, {});
+    sheet.render = () => {};
+
+    await sheet._toggleEditMode();
+
+    // Toggling must negate the *effective* state. Negating the raw flag would
+    // give !undefined === true, leaving an already-unlocked sheet unlocked.
+    expect(doc.setFlag).toHaveBeenCalledWith('megs', 'edit-mode', false);
 });

--- a/module/__tests__/actor.test.js
+++ b/module/__tests__/actor.test.js
@@ -236,3 +236,55 @@ describe('Character Budget Calculations', () => {
         expect(actor.system.heroPointBudget.remaining).toBe(372);
     });
 });
+
+// --- motivations (issue #243) -------------------------------------------------
+// An undefined motivation list makes the sheet's {{selectOptions}} throw
+// "Cannot convert undefined or null to object", which takes down the entire
+// sheet render. Every type whose sheet shows the motivation select needs one.
+describe('motivations', () => {
+    const buildActor = (type) => {
+        const actor = new MEGSActor({ system: { attributes: {} } });
+        actor.type = type;
+        actor.items = [];
+        return actor;
+    };
+
+    beforeEach(() => {
+        CONFIG.motivations = {
+            hero: ['Upholding the Good', 'Seeking Justice'],
+            villain: ['Power Lust', 'Mercenary'],
+            antihero: ['Unwanted Power', 'Thrill of Adventure'],
+        };
+    });
+
+    test('hero gets its own motivations plus antihero', () => {
+        const actor = buildActor(MEGS.characterTypes.hero);
+        actor.prepareBaseData();
+        actor.prepareDerivedData();
+
+        expect(actor.system.motivations).toContain('Upholding the Good');
+        expect(actor.system.motivations).toContain('Unwanted Power');
+        expect(actor.system.motivations).not.toContain('Power Lust');
+    });
+
+    test('villain gets its own motivations plus antihero', () => {
+        const actor = buildActor(MEGS.characterTypes.villain);
+        actor.prepareBaseData();
+        actor.prepareDerivedData();
+
+        expect(actor.system.motivations).toContain('Power Lust');
+        expect(actor.system.motivations).toContain('Thrill of Adventure');
+        expect(actor.system.motivations).not.toContain('Upholding the Good');
+    });
+
+    test('npc gets the full motivation list and is never undefined', () => {
+        const actor = buildActor(MEGS.characterTypes.npc);
+        actor.prepareBaseData();
+        actor.prepareDerivedData();
+
+        expect(actor.system.motivations).toBeDefined();
+        expect(actor.system.motivations).toContain('Upholding the Good');
+        expect(actor.system.motivations).toContain('Power Lust');
+        expect(actor.system.motivations).toContain('Unwanted Power');
+    });
+});

--- a/module/__tests__/item-sheet.test.js
+++ b/module/__tests__/item-sheet.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { MEGSItemSheet } from '../sheets/item-sheet.mjs';
 
 /*
@@ -8,6 +9,16 @@ From skill sheet - subskills
 From subskill sheet - subskill
 
 */
+
+/** Build an item document stand-in with a controllable stored edit-mode flag. */
+function mockDocument({ isOwner = true, compendiumSource = null, storedFlag } = {}) {
+    return {
+        isOwner,
+        _stats: { compendiumSource },
+        getFlag: jest.fn(() => storedFlag),
+        setFlag: jest.fn(),
+    };
+}
 const itemSheet = new MEGSItemSheet();
 // Provide a mock item with isOwner and setFlag for tests that require it
 itemSheet.item = { isOwner: true, setFlag: () => {} };
@@ -51,3 +62,56 @@ test('_isRollable returns false if no parent', () => {
 });
 
 // _prepareModifiers, _prepareSubskills, _prepareGadgetData are internal and require complex context, so skip direct unit tests unless you want to mock deeply.
+
+// --- edit-mode (issue #243) ---------------------------------------------------
+
+test('constructor does not write the edit-mode flag', () => {
+    const doc = mockDocument();
+    new MEGSItemSheet(doc, {});
+    // Writing a flag from the constructor races the first render: the render
+    // reads the old value, then the un-awaited write triggers a second render.
+    expect(doc.setFlag).not.toHaveBeenCalled();
+});
+
+test('isEditMode defaults to unlocked for an owner with no stored flag', () => {
+    const sheet = new MEGSItemSheet(mockDocument({ storedFlag: undefined }), {});
+    expect(sheet.isEditMode).toBe(true);
+});
+
+test('isEditMode honours a stored false flag for an owner', () => {
+    const sheet = new MEGSItemSheet(mockDocument({ storedFlag: false }), {});
+    expect(sheet.isEditMode).toBe(false);
+});
+
+test('isEditMode defaults to locked for a non-owner', () => {
+    const sheet = new MEGSItemSheet(mockDocument({ isOwner: false }), {});
+    expect(sheet.isEditMode).toBe(false);
+});
+
+test('isEditMode defaults to locked for a compendium item', () => {
+    const doc = mockDocument({ compendiumSource: 'Compendium.megs.powers.Item.abc' });
+    const sheet = new MEGSItemSheet(doc, {});
+    expect(sheet.isEditMode).toBe(false);
+});
+
+test('_toggleEditMode locks a sheet that is unlocked by default', async () => {
+    const doc = mockDocument({ storedFlag: undefined });
+    const sheet = new MEGSItemSheet(doc, {});
+    sheet.render = () => {};
+
+    await sheet._toggleEditMode();
+
+    // Toggling must negate the *effective* state. Negating the raw flag would
+    // give !undefined === true, leaving an already-unlocked sheet unlocked.
+    expect(doc.setFlag).toHaveBeenCalledWith('megs', 'edit-mode', false);
+});
+
+test('_toggleEditMode unlocks a sheet with a stored false flag', async () => {
+    const doc = mockDocument({ storedFlag: false });
+    const sheet = new MEGSItemSheet(doc, {});
+    sheet.render = () => {};
+
+    await sheet._toggleEditMode();
+
+    expect(doc.setFlag).toHaveBeenCalledWith('megs', 'edit-mode', true);
+});

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -152,7 +152,11 @@ export class MEGSActor extends Actor {
         // Calculate Hero Point budget and spending
         this._calculateHeroPointBudget();
 
-        if (this.type === MEGS.characterTypes.hero || this.type === MEGS.characterTypes.villain) {
+        if (
+            this.type === MEGS.characterTypes.hero ||
+            this.type === MEGS.characterTypes.villain ||
+            this.type === MEGS.characterTypes.npc
+        ) {
             const merge = (a, b, predicate = (a, b) => a === b) => {
                 const c = [...a]; // copy to avoid side effects
                 // add all items from B to copy C if they're not already present
@@ -161,10 +165,16 @@ export class MEGSActor extends Actor {
                 );
                 return c;
             };
-            this.system.motivations = merge(
-                CONFIG.motivations[this.type],
-                CONFIG.motivations.antihero
-            );
+            // NPCs may be aligned either way, so they get every motivation; heroes
+            // and villains get their own list plus the antihero motivations. This
+            // must be defined for every type whose sheet renders the motivation
+            // select -- selectOptions throws on an undefined choice list, which
+            // takes down the whole sheet render.
+            const base =
+                this.type === MEGS.characterTypes.npc
+                    ? merge(CONFIG.motivations.hero, CONFIG.motivations.villain)
+                    : CONFIG.motivations[this.type];
+            this.system.motivations = merge(base, CONFIG.motivations.antihero);
         }
     }
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -7,13 +7,31 @@ import { Utils } from '../utils.js';
  * @extends {ActorSheet}
  */
 export class MEGSActorSheet extends ActorSheet {
-    /** @override */
-    constructor(object, options) {
-        super(object, options);
-        if (this.actor) {
-            const isUnlocked = this.actor.isOwner && !this.actor._stats.compendiumSource;
-            this.actor.setFlag('megs', 'edit-mode', isUnlocked);
+    /**
+     * Lock state for an actor that has no stored edit-mode flag: unlocked for an
+     * owner, locked for a non-owner or a compendium actor.
+     * @returns {boolean}
+     */
+    get defaultEditMode() {
+        if (!this.actor) {
+            return false;
         }
+        return Boolean(this.actor.isOwner) && !this.actor._stats?.compendiumSource;
+    }
+
+    /**
+     * The effective edit-mode state: the stored flag when the user has set one,
+     * otherwise the ownership-derived default. Derived on read rather than
+     * written on construction, because writing the flag races the render that
+     * reads it (issue #243).
+     * @returns {boolean}
+     */
+    get isEditMode() {
+        const storedFlag = this.actor?.getFlag('megs', 'edit-mode');
+        if (storedFlag === undefined || storedFlag === null) {
+            return this.defaultEditMode;
+        }
+        return storedFlag === true;
     }
 
     /** @override */
@@ -53,7 +71,11 @@ export class MEGSActorSheet extends ActorSheet {
 
         // Add the actor's data to context.data for easier access, as well as flags.
         context.system = actorData.system;
-        context.flags = actorData.flags;
+        context.flags = actorData.flags ?? {};
+
+        // Templates read flags.megs.edit-mode directly. actorData is a clone, so
+        // surface the effective state here without writing it to the document.
+        context.flags.megs = { ...context.flags.megs, 'edit-mode': this.isEditMode };
 
         // Prepare character data and items for hero, villain, and npc types.
         if (actorData.type === MEGS.characterTypes.hero ||
@@ -1206,14 +1228,15 @@ export class MEGSActorSheet extends ActorSheet {
         }
     }
 
-    _toggleEditMode(event) {
+    async _toggleEditMode(event) {
         // Save accordion state before toggling edit mode
         if (this.element && this.element.length > 0) {
             this._saveAccordionState(this.element);
         }
 
-        const currentValue = this.actor.getFlag('megs', 'edit-mode');
-        this.actor.setFlag('megs', 'edit-mode', !currentValue);
+        // Negate the effective state, not the stored flag: an unset flag would
+        // give !undefined === true and leave an unlocked sheet unlocked.
+        await this.actor.setFlag('megs', 'edit-mode', !this.isEditMode);
         this.render(false);
     }
 

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -9,14 +9,31 @@ import { Utils } from '../utils.js';
  * @extends {ItemSheet}
  */
 export class MEGSItemSheet extends ItemSheet {
-    /** @override */
-    constructor(object, options) {
-        super(object, options);
-        // default to uneditable if user is not owner or from a compendium
-        if (this.object) {
-            const isUnlocked = this.object.isOwner && !this.object._stats.compendiumSource;
-            this.object.setFlag('megs', 'edit-mode', isUnlocked);
+    /**
+     * Lock state for an item that has no stored edit-mode flag: unlocked for an
+     * owner, locked for a non-owner or a compendium item.
+     * @returns {boolean}
+     */
+    get defaultEditMode() {
+        if (!this.object) {
+            return false;
         }
+        return Boolean(this.object.isOwner) && !this.object._stats?.compendiumSource;
+    }
+
+    /**
+     * The effective edit-mode state: the stored flag when the user has set one,
+     * otherwise the ownership-derived default. Derived on read rather than
+     * written on construction, because writing the flag races the render that
+     * reads it (issue #243).
+     * @returns {boolean}
+     */
+    get isEditMode() {
+        const storedFlag = this.object?.getFlag('megs', 'edit-mode');
+        if (storedFlag === undefined || storedFlag === null) {
+            return this.defaultEditMode;
+        }
+        return storedFlag === true;
     }
 
     /** @override */
@@ -59,7 +76,11 @@ export class MEGSItemSheet extends ItemSheet {
 
         // Add the item's data to context.data for easier access, as well as flags.
         context.system = itemData.system;
-        context.flags = itemData.flags;
+        context.flags = itemData.flags ?? {};
+
+        // Templates read flags.megs.edit-mode directly. itemData is a clone, so
+        // surface the effective state here without writing it to the document.
+        context.flags.megs = { ...context.flags.megs, 'edit-mode': this.isEditMode };
 
         if (itemData.type === MEGS.itemTypes.power) {
             this._prepareModifiers(context);
@@ -246,8 +267,8 @@ export class MEGSItemSheet extends ItemSheet {
         // Initialize subskill checkbox states based on skill APs
         if (this.object.type === 'skill') {
             const skillAps = this.object.system.aps || 0;
-            // Check the custom edit-mode flag (not Foundry's isEditable)
-            const isEditMode = this.object.getFlag('megs', 'edit-mode') === true;
+            // Check the custom edit-mode state (not Foundry's isEditable)
+            const isEditMode = this.isEditMode;
             const checkboxes = html.find('.subskills input[type="checkbox"][name^="items."]');
 
             checkboxes.each(function () {
@@ -1499,9 +1520,10 @@ export class MEGSItemSheet extends ItemSheet {
         }
     }
 
-    _toggleEditMode(_e) {
-        const currentValue = this.object.getFlag('megs', 'edit-mode');
-        this.object.setFlag('megs', 'edit-mode', !currentValue);
+    async _toggleEditMode(_e) {
+        // Negate the effective state, not the stored flag: an unset flag would
+        // give !undefined === true and leave an unlocked sheet unlocked.
+        await this.object.setFlag('megs', 'edit-mode', !this.isEditMode);
         this.render(false);
     }
 }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/243-item-sheet-constructor-setflag-race/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/243-item-sheet-constructor-setflag-race/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/243-item-sheet-constructor-setflag-race",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
Fixes #243

## The race

`MEGSItemSheet` and `MEGSActorSheet` both wrote the edit-mode flag from their constructor with an un-awaited `setFlag`. The write raced the first render: the render read the old flag, then the document update landed and triggered a *second* render with the new value, so which state the user saw depended on timing. It also stomped any edit-mode state set before the sheet was first constructed, wrote the flag for non-owners and compendium documents, and cost a database write on every sheet open.

Both constructors are gone. The lock state is derived on read:

- `defaultEditMode` — owner and not from a compendium
- `isEditMode` — the stored flag when one exists, otherwise `defaultEditMode`

`getData` injects the effective value into `context.flags.megs['edit-mode']` on the document *clone*, so the ~100 existing `{{#if flags.megs.edit-mode}}` template references keep working unchanged without writing to the document.

`_toggleEditMode` now negates the **effective** state rather than the raw flag. With no stored flag, `!undefined` is `true`, which would have left an already-unlocked sheet unlocked — the first click of the Edit button would have appeared to do nothing. It also awaits the write before re-rendering, closing the same race in a second place.

`MEGSCharacterBuilderSheet` and `MEGSGadgetBuilderSheet` inherit from these two and declare no constructors, so all four sheets are covered.

## The latent NPC crash this exposed

Once edit-mode is derived correctly on the *first* render, the NPC sheet stops rendering entirely:

```
TypeError: Cannot convert undefined or null to object
    at Object.entries (<anonymous>)
    at Object.selectOptions (foundry.mjs)
```

`system.motivations` was only populated for heroes and villains (`motivations.json` has no `npc` key), and `actor-description.hbs` feeds it straight to `{{selectOptions}}`, which calls `Object.entries` on the choice list — but **only in edit mode**. On an NPC that list is `undefined`, the exception escapes the template, and the whole sheet render fails.

The race was hiding it: the first render read an unset flag, drew the sheet in view mode, and skipped the select. The flag write then landed and the re-render threw, but the sheet was already on screen. **The NPC sheet in edit mode has been broken this whole time.**

NPCs now receive the full motivation list (hero + villain + antihero), since an NPC may be aligned either way. Heroes and villains keep their own list plus antihero. Verified across every actor type:

| type | `system.motivations` | render before | render after |
|---|---|---|---|
| hero | object | OK | OK |
| villain | object | OK | OK |
| **npc** | **undefined** | **THREW** | **OK** |
| vehicle | undefined | OK | OK |
| location | undefined | OK | OK |

## Why the unit tests never caught the race

The Jest `ItemSheet`/`ActorSheet` mocks never set `this.object`, which Foundry's real `DocumentSheet` constructor does — so `if (this.object)` was always false and the constructors' flag-writing branch was **dead code in every unit test**. The mocks now set it, and both sheets have unit coverage for edit-mode derivation and toggling.

## Behaviour change

Edit/view mode now **persists per document** across sheet closes. Previously an owner had edit mode forced back on every time a sheet was opened.

## Testing

- Jest: **89 passed** (12 new for edit-mode derivation/toggling, 3 new for motivations)
- Playwright: **132 passed, 1 flaky, 0 failed**. The flaky one is `active-effects.spec.mjs:66`, which passes on retry and also flaked on the release branch before this change.
- New E2E regression test: an item locked before its sheet is ever constructed stays locked when opened.
- Removed the E2E workarounds that constructed a sheet before setting the flag, and awaited `setFlag` calls that were previously fire-and-forget.

## Unrelated bug found

`templates/actor/actor-pet-sheet.hbs` does not exist, so opening a `pet` actor's sheet fails with `ENOENT`. This reproduces on the release branch and is not touched here — it deserves its own issue.
