### PR TITLE
Coerce getAPCost inputs to reject empty strings and NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fixed item and actor sheets overwriting the edit-mode flag on every open — the sheet constructors wrote the flag with an un-awaited `setFlag` that raced the first render; the lock state is now derived at render time, so edit/view mode persists per document and no longer flips back to edit mode when a sheet is reopened (issue #243)
 - Fixed the edit-mode toggle negating the stored flag rather than the effective state, and no longer writing the flag for non-owners or compendium documents (issue #243)
 - Fixed the NPC sheet failing to render in edit mode — NPCs had no `system.motivations`, so the motivation `selectOptions` threw `Cannot convert undefined or null to object` and took down the entire sheet render; NPCs now receive the full motivation list (hero, villain, and antihero). This was masked by the edit-mode flag race, which left the first render in view mode (issue #243)
+- Fixed `getAPCost` accepting empty strings, NaN, and other non-numeric values — inputs are now coerced via `Number()` so form-cleared fields and unset data properties return 0 instead of falling through to a spurious console warning (issue #244)
 
 ### Testing
 
@@ -41,6 +42,7 @@
 - Added new E2E tests for: trait subtext (#209), trait drop blocking (#178, #3), chat message formatting (#93), accordion state persistence (#67), reliability number (#8)
 - Fixed the `ItemSheet`/`ActorSheet` Jest mocks not setting `this.object`, which left the sheet constructors' flag-writing branch as dead code in every unit test and hid issue #243; added unit coverage for edit-mode derivation and toggling (issue #243)
 - Removed E2E workarounds that constructed a sheet before setting the edit-mode flag, and awaited `setFlag` calls that were previously fire-and-forget (issue #243)
+- Added unit tests for `MEGS.getAPCost` edge inputs: empty string, numeric string, NaN, null, undefined, negative, and boundary values (issue #244)
 
 ### Code Quality
 

--- a/module/__tests__/config.test.js
+++ b/module/__tests__/config.test.js
@@ -1,0 +1,79 @@
+/* eslint-env jest */
+import '../__mocks__/foundry.mjs';
+/* global CONFIG */
+
+import { MEGS } from '../helpers/config.mjs';
+
+beforeAll(async () => {
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const { fileURLToPath } = await import('url');
+
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    const chartPath = path.join(__dirname, '../../assets/data/apCostChart.json');
+
+    const chartData = await fs.readFile(chartPath, 'utf-8');
+    CONFIG.apCostChart = JSON.parse(chartData);
+});
+
+describe('MEGS.getAPCost', () => {
+    test('returns correct cost for valid numeric inputs', () => {
+        // 8 APs at FC 6 = 60 HP (from AP Purchase Chart)
+        expect(MEGS.getAPCost(8, 6)).toBe(60);
+    });
+
+    test('returns 0 for 0 APs', () => {
+        expect(MEGS.getAPCost(0, 6)).toBe(0);
+    });
+
+    test('coerces numeric string APs to number', () => {
+        expect(MEGS.getAPCost('8', 6)).toBe(60);
+    });
+
+    test('coerces empty string APs to 0 (costs 0)', () => {
+        expect(MEGS.getAPCost('', 6)).toBe(0);
+    });
+
+    test('returns 0 for NaN APs', () => {
+        expect(MEGS.getAPCost(NaN, 6)).toBe(0);
+    });
+
+    test('returns 0 for null APs', () => {
+        expect(MEGS.getAPCost(null, 6)).toBe(0);
+    });
+
+    test('returns 0 for undefined APs', () => {
+        expect(MEGS.getAPCost(undefined, 6)).toBe(0);
+    });
+
+    test('returns 0 for negative APs', () => {
+        expect(MEGS.getAPCost(-1, 6)).toBe(0);
+    });
+
+    test('calculates cost for APs over 40 using incremental formula', () => {
+        const cost = MEGS.getAPCost(41, 6);
+        expect(cost).toBeGreaterThan(0);
+        expect(typeof cost).toBe('number');
+    });
+
+    test('returns 0 for FC below 1', () => {
+        expect(MEGS.getAPCost(8, 0)).toBe(0);
+    });
+
+    test('returns 0 for FC above 10', () => {
+        expect(MEGS.getAPCost(8, 11)).toBe(0);
+    });
+
+    test('returns 0 for non-numeric string APs', () => {
+        expect(MEGS.getAPCost('abc', 6)).toBe(0);
+    });
+
+    test('coerces numeric string FC to number', () => {
+        expect(MEGS.getAPCost(8, '6')).toBe(60);
+    });
+
+    test('returns 0 for empty string FC', () => {
+        expect(MEGS.getAPCost(8, '')).toBe(0);
+    });
+});

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -273,7 +273,7 @@ export class MEGSActor extends Actor {
         }
 
         // Calculate HP spent on wealth (FC 2)
-        const wealthCost = MEGS.getAPCost(this.system.wealth ?? 0, 2) || 0;
+        const wealthCost = MEGS.getAPCost(Number(this.system.wealth) || 0, 2) || 0;
 
         // Calculate HP spent on items (powers, skills, advantages, gadgets, drawbacks)
         let itemsCost = 0;

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -119,16 +119,16 @@ MEGS.yesNoOptions = {
  * @returns {number} The Hero Point cost, or 0 if invalid parameters
  */
 MEGS.getAPCost = function (aps, factorCost) {
-    // Validate inputs - 0 APs is valid (costs 0), but FC must be 1-10
-    if (aps === null || aps === undefined || aps < 0 ||
-        factorCost === null || factorCost === undefined || factorCost < 1 || factorCost > 10) {
+    aps = Number(aps);
+    factorCost = Number(factorCost);
+
+    if (isNaN(aps) || aps < 0 || isNaN(factorCost) || factorCost < 1 || factorCost > 10) {
         if (game.settings.get('megs', 'debugLogging')) {
             console.warn(`Invalid AP cost lookup: ${aps} APs at FC ${factorCost}`);
         }
         return 0;
     }
 
-    // 0 APs always costs 0 HP
     if (aps === 0) {
         return 0;
     }

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -201,29 +201,17 @@ Handlebars.registerHelper('toLowerCase', function (str) {
 });
 
 Handlebars.registerHelper('getAttributeCost', function (aps, factorCost) {
-    // Validate inputs before calling getAPCost
     if (!CONFIG.MEGS || !CONFIG.MEGS.getAPCost) {
         return 0;
     }
-
-    // Ensure aps and factorCost are valid numbers (not undefined/null)
-    const validAPs = (aps !== undefined && aps !== null) ? aps : 0;
-    const validFC = (factorCost !== undefined && factorCost !== null) ? factorCost : 0;
-
-    return CONFIG.MEGS.getAPCost(validAPs, validFC) || 0;
+    return CONFIG.MEGS.getAPCost(Number(aps) || 0, Number(factorCost) || 0) || 0;
 });
 
 Handlebars.registerHelper('getAPCost', function (aps, factorCost) {
-    // Validate inputs before calling getAPCost
     if (!CONFIG.MEGS || !CONFIG.MEGS.getAPCost) {
         return 0;
     }
-
-    // Ensure aps and factorCost are valid numbers (not undefined/null)
-    const validAPs = (aps !== undefined && aps !== null) ? aps : 0;
-    const validFC = (factorCost !== undefined && factorCost !== null) ? factorCost : 0;
-
-    return CONFIG.MEGS.getAPCost(validAPs, validFC) || 0;
+    return CONFIG.MEGS.getAPCost(Number(aps) || 0, Number(factorCost) || 0) || 0;
 });
 
 Handlebars.registerHelper('trueFalseToYesNo', function (str) {
@@ -1083,6 +1071,7 @@ Handlebars.registerHelper('getGadgetCostTooltip', function (gadget) {
 });
 
 Handlebars.registerHelper('getGadgetAttributeCost', function (aps, baseFc, reliabilityIndex, hasHardenedDefenses, attrKey) {
+    aps = Number(aps) || 0;
     if (aps === 0) return 0;
 
     const table = { 0: 3, 2: 2, 3: 1, 5: 0, 7: -1, 9: -2, 11: -3 };

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/244-getapcost-empty-value-validation/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/244-getapcost-empty-value-validation/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/244-getapcost-empty-value-validation",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary

- `MEGS.getAPCost` now coerces both `aps` and `factorCost` via `Number()` at entry, replacing the `null`/`undefined`/range guards that let empty strings, NaN, and numeric strings slip through
- Tightened callers: Handlebars helpers (`getAttributeCost`, `getAPCost`, `getGadgetAttributeCost`) and the actor wealth calculation (`_calculateHeroPointBudget`) now coerce inputs before passing them downstream
- Added 14 unit tests covering edge inputs: `''`, `'8'`, `NaN`, `null`, `undefined`, `0`, `-1`, `41`, FC boundaries, and non-numeric strings

## Test plan

- [x] Jest: all 103 tests pass (6 suites)
- [x] Lint: no new errors in changed files (pre-existing `??` linebreak warnings in megs.mjs unchanged)
- [x] E2E: existing `reliability-number.spec.mjs` "Gadget cost tooltip shows the cost breakdown with final cost" should now return `Final Cost: 15` instead of `Final Cost: 0` — verify on merge

Fixes #244