### PR TITLE
Fix accordion state lost on uninstrumented re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fixed the edit-mode toggle negating the stored flag rather than the effective state, and no longer writing the flag for non-owners or compendium documents (issue #243)
 - Fixed the NPC sheet failing to render in edit mode — NPCs had no `system.motivations`, so the motivation `selectOptions` threw `Cannot convert undefined or null to object` and took down the entire sheet render; NPCs now receive the full motivation list (hero, villain, and antihero). This was masked by the edit-mode flag race, which left the first render in view mode (issue #243)
 - Fixed `getAPCost` accepting empty strings, NaN, and other non-numeric values — inputs are now coerced via `Number()` so form-cleared fields and unset data properties return 0 instead of falling through to a spurious console warning (issue #244)
+- Fixed accordion expanded state lost on re-renders not triggered by instrumented handlers — accordion state is now saved in the `_render` lifecycle override before the DOM is replaced, so expanded rows survive any re-render source (programmatic, multiplayer, token bar changes) (issue #242)
 
 ### Testing
 
@@ -43,6 +44,7 @@
 - Fixed the `ItemSheet`/`ActorSheet` Jest mocks not setting `this.object`, which left the sheet constructors' flag-writing branch as dead code in every unit test and hid issue #243; added unit coverage for edit-mode derivation and toggling (issue #243)
 - Removed E2E workarounds that constructed a sheet before setting the edit-mode flag, and awaited `setFlag` calls that were previously fire-and-forget (issue #243)
 - Added unit tests for `MEGS.getAPCost` edge inputs: empty string, numeric string, NaN, null, undefined, negative, and boundary values (issue #244)
+- Removed `test.fail()` markers from accordion E2E tests now that #242 is fixed (issue #242)
 
 ### Code Quality
 

--- a/e2e/tests/accordion-state.spec.mjs
+++ b/e2e/tests/accordion-state.spec.mjs
@@ -11,9 +11,6 @@ import {
 
 test.describe('Accordion State Persistence (#67)', () => {
     test('Expanded skill row stays expanded after re-render', async ({ page }) => {
-        // KNOWN BUG #242: accordion state is lost on re-renders that don't go
-        // through the instrumented handlers. Remove this once #242 is fixed.
-        test.fail();
         let actorId;
         try {
             actorId = await createHeroActor(page, prefixName('Accordion_Expand'));
@@ -116,9 +113,6 @@ test.describe('Accordion State Persistence (#67)', () => {
     });
 
     test('Mixed accordion states survive re-render independently', async ({ page }) => {
-        // KNOWN BUG #242: accordion state is lost on re-renders that don't go
-        // through the instrumented handlers. Remove this once #242 is fixed.
-        test.fail();
         let actorId;
         try {
             actorId = await createHeroActor(page, prefixName('Accordion_Mixed'));

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -518,6 +518,14 @@ export class MEGSActorSheet extends ActorSheet {
     /* -------------------------------------------- */
 
     /** @override */
+    async _render(force, options) {
+        if (this.element?.length > 0) {
+            this._saveAccordionState(this.element);
+        }
+        await super._render(force, options);
+    }
+
+    /** @override */
     activateListeners(html) {
         super.activateListeners(html);
 
@@ -572,9 +580,6 @@ export class MEGSActorSheet extends ActorSheet {
             const itemId = $(ev.currentTarget).data('itemId');
             const item = this.actor.items.get(itemId);
             if (item && item.type === 'subskill') {
-                // Save accordion state before render
-                this._saveAccordionState(html);
-
                 await item.update({ 'system.isTrained': ev.currentTarget.checked });
                 this.render(false);
             }
@@ -653,9 +658,6 @@ export class MEGSActorSheet extends ActorSheet {
             return;
         }
 
-        // Save accordion state before render
-        this._saveAccordionState(html);
-
         await item.update({ 'system.aps': newValue });
         this.render(false);
     }
@@ -716,10 +718,6 @@ export class MEGSActorSheet extends ActorSheet {
         });
 
         if (!confirmed) return;
-
-        // Save accordion state before deletion
-        const html = $(event.currentTarget).closest('.sheet');
-        this._saveAccordionState(html);
 
         // If deleting a power or skill, also delete all associated bonuses/limitations
         if (item.type === 'power' || item.type === 'skill') {
@@ -894,10 +892,6 @@ export class MEGSActorSheet extends ActorSheet {
 
         // Check if item already belongs to this actor
         const isOnActor = droppedItem.parent?.id === this.actor.id;
-
-        // Save accordion state before re-render
-        const html = $(event.currentTarget).closest('.sheet');
-        this._saveAccordionState(html);
 
         if (isOnActor) {
             // Item is already on this actor - update its parent (move it)
@@ -1163,15 +1157,6 @@ export class MEGSActorSheet extends ActorSheet {
     }
 
     /** @override **/
-    async _onDrop(event) {
-        // Save accordion state before any drop operation
-        const html = $(event.currentTarget).closest('.sheet');
-        this._saveAccordionState(html);
-
-        super._onDrop(event);
-    }
-
-    /** @override **/
     async _onDropItemCreate(itemData) {
         const items = Array.isArray(itemData) ? itemData : [itemData];
         const isTrait = (i) => i.type === 'advantage' || i.type === 'drawback';
@@ -1229,11 +1214,6 @@ export class MEGSActorSheet extends ActorSheet {
     }
 
     async _toggleEditMode(event) {
-        // Save accordion state before toggling edit mode
-        if (this.element && this.element.length > 0) {
-            this._saveAccordionState(this.element);
-        }
-
         // Negate the effective state, not the stored flag: an unset flag would
         // give !undefined === true and leave an unlocked sheet unlocked.
         await this.actor.setFlag('megs', 'edit-mode', !this.isEditMode);

--- a/module/sheets/character-creator-sheet.mjs
+++ b/module/sheets/character-creator-sheet.mjs
@@ -147,9 +147,6 @@ export class MEGSCharacterBuilderSheet extends MEGSActorSheet {
             const itemId = $(ev.currentTarget).data('itemId');
             const item = this.actor.items.get(itemId);
             if (item && item.type === 'subskill') {
-                // Save accordion state before render
-                this._saveAccordionState(html);
-
                 await item.update({ 'system.isTrained': ev.currentTarget.checked });
                 this.render(false);
             }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/242-accordion-state-persistence/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/242-accordion-state-persistence/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/242-accordion-state-persistence",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary

- Overrides `_render()` in `MEGSActorSheet` to save accordion state from the live DOM before `super._render()` replaces it — mirrors how Foundry preserves scroll positions
- Removes 7 per-handler `_saveAccordionState` calls (subskill checkbox, AP +/-, item delete, drag/drop, edit-mode toggle) that are now redundant
- Removes the passthrough `_onDrop` override that existed only to save accordion state
- Removes `test.fail()` markers from 2 E2E tests that now pass

## Test plan

- [x] 103 Jest tests pass
- [x] ESLint clean on changed files
- [x] 3 accordion E2E tests pass (including 2 previously marked as known-failing)
- [x] Manual: expand rows, then toggle isTrained, change APs, delete an item, render via console — expanded rows survive all four

Fixes #242