### PR TITLE
Fix gadget builder attribute HP costs always showing 0

### DIFF
--- a/e2e/tests/gadget-builder-costs.spec.mjs
+++ b/e2e/tests/gadget-builder-costs.spec.mjs
@@ -1,0 +1,282 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    addGadgetToActor,
+    deleteActor,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+
+/**
+ * Verifies that the Gadget Builder sheet correctly displays HP costs
+ * for attributes. Regression test for #255.
+ */
+test.describe('Gadget Builder Attribute Costs (#255)', () => {
+    test('Body 2 at R#5 (reliability index 3) shows 6 HP', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('GBCost_R5'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Test Gadget R5',
+                attrs: { body: 2 },
+                reliability: 3, // Index 3 = R#5, no FC modifier
+            });
+
+            // Open gadget builder sheet
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                await gadget.setFlag('core', 'sheetClass', 'megs.MEGSGadgetBuilderSheet');
+                gadget.sheet.render(true);
+            }, { actorId, gadgetId });
+            await page.waitForSelector('.sheet.item.gadget-builder', { timeout: 5000 });
+
+            // Get the Body attribute cost text
+            const bodyCost = await page.evaluate(() => {
+                const rows = document.querySelectorAll('.sheet.item.gadget-builder .attribute');
+                for (const row of rows) {
+                    const label = row.querySelector('.resource-label');
+                    if (label && label.textContent.trim() === 'BODY') {
+                        const cost = row.querySelector('.cost-value');
+                        return cost ? cost.textContent.trim() : null;
+                    }
+                }
+                return null;
+            });
+
+            // 2 APs at FC 6 = 6 HP
+            expect(bodyCost).toBe('6 HP');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Body 2 at R#0 (reliability index 0) shows 9 HP', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('GBCost_R0'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Test Gadget R0',
+                attrs: { body: 2 },
+                reliability: 0, // Index 0 = R#0, +3 to FC
+            });
+
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                await gadget.setFlag('core', 'sheetClass', 'megs.MEGSGadgetBuilderSheet');
+                gadget.sheet.render(true);
+            }, { actorId, gadgetId });
+            await page.waitForSelector('.sheet.item.gadget-builder', { timeout: 5000 });
+
+            const bodyCost = await page.evaluate(() => {
+                const rows = document.querySelectorAll('.sheet.item.gadget-builder .attribute');
+                for (const row of rows) {
+                    const label = row.querySelector('.resource-label');
+                    if (label && label.textContent.trim() === 'BODY') {
+                        const cost = row.querySelector('.cost-value');
+                        return cost ? cost.textContent.trim() : null;
+                    }
+                }
+                return null;
+            });
+
+            // 2 APs at FC (6+3=9) = 9 HP
+            expect(bodyCost).toBe('9 HP');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Changing reliability updates displayed costs', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('GBCost_Change'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Test Gadget Change',
+                attrs: { body: 2 },
+                reliability: 3, // Start at R#5
+            });
+
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                await gadget.setFlag('core', 'sheetClass', 'megs.MEGSGadgetBuilderSheet');
+                gadget.sheet.render(true);
+            }, { actorId, gadgetId });
+            await page.waitForSelector('.sheet.item.gadget-builder', { timeout: 5000 });
+
+            // Change reliability to index 0 (R#0, +3 to FC)
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                await gadget.update({ 'system.reliability': 0 });
+            }, { actorId, gadgetId });
+            await page.waitForTimeout(500);
+
+            const bodyCost = await page.evaluate(() => {
+                const rows = document.querySelectorAll('.sheet.item.gadget-builder .attribute');
+                for (const row of rows) {
+                    const label = row.querySelector('.resource-label');
+                    if (label && label.textContent.trim() === 'BODY') {
+                        const cost = row.querySelector('.cost-value');
+                        return cost ? cost.textContent.trim() : null;
+                    }
+                }
+                return null;
+            });
+
+            // After changing to R#0: 2 APs at FC (6+3=9) = 9 HP
+            expect(bodyCost).toBe('9 HP');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Hardened Defenses at R#0 clamps FC to 10', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('GBCost_HD'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Armored Device',
+                attrs: { body: 2 },
+                reliability: 0, // R#0, +3 to FC
+            });
+
+            // Enable Hardened Defenses (+2 to Body FC)
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                await gadget.update({ 'system.hasHardenedDefenses': true });
+                await gadget.setFlag('core', 'sheetClass', 'megs.MEGSGadgetBuilderSheet');
+                gadget.sheet.render(true);
+            }, { actorId, gadgetId });
+            await page.waitForSelector('.sheet.item.gadget-builder', { timeout: 5000 });
+
+            const bodyCost = await page.evaluate(() => {
+                const rows = document.querySelectorAll('.sheet.item.gadget-builder .attribute');
+                for (const row of rows) {
+                    const label = row.querySelector('.resource-label');
+                    if (label && label.textContent.trim() === 'BODY') {
+                        const cost = row.querySelector('.cost-value');
+                        return cost ? cost.textContent.trim() : null;
+                    }
+                }
+                return null;
+            });
+
+            // Body FC: 6 + 3 (R#0) + 2 (Hardened) = 11, clamped to 10
+            // 2 APs at FC 10 = 10 HP
+            expect(bodyCost).toBe('10 HP');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Budget attributesCost matches sum of individual costs', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('GBCost_Budget'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Multi-Attr Device',
+                attrs: { body: 2, dex: 3 },
+                reliability: 3, // R#5, no modifier
+            });
+
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                await gadget.setFlag('core', 'sheetClass', 'megs.MEGSGadgetBuilderSheet');
+                gadget.sheet.render(true);
+            }, { actorId, gadgetId });
+            await page.waitForSelector('.sheet.item.gadget-builder', { timeout: 5000 });
+
+            const result = await page.evaluate(() => {
+                const rows = document.querySelectorAll('.sheet.item.gadget-builder .attribute');
+                const costs = {};
+                for (const row of rows) {
+                    const label = row.querySelector('.resource-label');
+                    const cost = row.querySelector('.cost-value');
+                    if (label && cost) {
+                        const name = label.textContent.trim();
+                        const hp = parseInt(cost.textContent);
+                        if (!isNaN(hp) && hp > 0) costs[name] = hp;
+                    }
+                }
+
+                // Get budget summary attributesCost
+                const summaryRows = document.querySelectorAll('.sheet.item.gadget-builder .attributes-summary .summary-row');
+                let budgetCost = null;
+                for (const row of summaryRows) {
+                    const label = row.querySelector('.summary-label');
+                    if (label && label.textContent.includes('Attributes')) {
+                        const value = row.querySelector('.summary-value');
+                        budgetCost = value ? value.textContent.trim() : null;
+                        break;
+                    }
+                }
+
+                return { costs, budgetCost };
+            });
+
+            // Body: 2 APs @ FC 6 = 6 HP
+            // DEX: 3 APs @ FC 7 = 14 HP
+            expect(result.costs['BODY']).toBe(6);
+            expect(result.costs['DEX']).toBe(14);
+
+            // Budget total should show (6+14)/4 = ceil(20/4) = 5 HP (with gadget bonus ÷4)
+            expect(result.budgetCost).toBe('5 HP');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('Incrementing attribute via plus button updates cost', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('GBCost_Plus'));
+            const gadgetId = await addGadgetToActor(page, actorId, {
+                name: 'Plus Button Device',
+                attrs: { body: 0 },
+                reliability: 3, // R#5, no modifier
+            });
+
+            await page.evaluate(async ({ actorId, gadgetId }) => {
+                const actor = game.actors.get(actorId);
+                const gadget = actor.items.get(gadgetId);
+                await gadget.setFlag('core', 'sheetClass', 'megs.MEGSGadgetBuilderSheet');
+                gadget.sheet.render(true);
+            }, { actorId, gadgetId });
+            await page.waitForSelector('.sheet.item.gadget-builder', { timeout: 5000 });
+
+            // Click plus button for Body twice
+            for (let i = 0; i < 2; i++) {
+                await page.click('.sheet.item.gadget-builder .attribute-plus[data-attribute="body"]');
+                await page.waitForTimeout(300);
+            }
+
+            const bodyCost = await page.evaluate(() => {
+                const rows = document.querySelectorAll('.sheet.item.gadget-builder .attribute');
+                for (const row of rows) {
+                    const label = row.querySelector('.resource-label');
+                    if (label && label.textContent.trim() === 'BODY') {
+                        const cost = row.querySelector('.cost-value');
+                        return cost ? cost.textContent.trim() : null;
+                    }
+                }
+                return null;
+            });
+
+            // Body 2 APs at FC 6 (R#5) = 6 HP
+            expect(bodyCost).toBe('6 HP');
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/module/__tests__/item.test.js
+++ b/module/__tests__/item.test.js
@@ -283,3 +283,68 @@ describe('Base Cost Only Powers', () => {
         expect(power.system.totalCost).toBe(80);
     });
 });
+
+describe('Gadget Attribute FC Clamping', () => {
+    test('FC is clamped to max 10 when reliability + hardened defenses exceeds limit', () => {
+        const gadget = new MEGSItem({
+            name: 'Over-FC Device',
+            type: 'gadget',
+            system: {
+                attributes: {
+                    body: { value: 2, factorCost: 6 }
+                },
+                reliability: 0, // R# 0, +3 to FC
+                hasHardenedDefenses: true, // +2 to BODY FC
+                canBeTakenAway: true
+            }
+        });
+
+        gadget.prepareDerivedData();
+
+        // Body FC: 6 + 3 (R#0) + 2 (Hardened) = 11, clamped to 10
+        // 2 APs @ FC 10 = 10, ÷4 = 3
+        expect(gadget.system.totalCost).toBe(3);
+    });
+
+    test('string factorCost is coerced to number', () => {
+        const gadget = new MEGSItem({
+            name: 'String FC Device',
+            type: 'gadget',
+            system: {
+                attributes: {
+                    body: { value: 2, factorCost: '6' }
+                },
+                reliability: 3, // R# 5, no modifier
+                canBeTakenAway: true
+            }
+        });
+
+        gadget.prepareDerivedData();
+
+        // Body FC: 6 + 0 = 6; 2 APs @ FC 6 = 6, ÷4 = 2
+        expect(gadget.system.totalCost).toBe(2);
+    });
+
+    test('gadgetPointBudget attributesCost matches individual calculation', () => {
+        const gadget = new MEGSItem({
+            name: 'Budget Test',
+            type: 'gadget',
+            system: {
+                attributes: {
+                    body: { value: 2, factorCost: 6 },
+                    dex: { value: 3, factorCost: 7 }
+                },
+                reliability: 3, // R# 5, no modifier
+                canBeTakenAway: true,
+                creationBudget: { base: 100 }
+            }
+        });
+
+        gadget.prepareDerivedData();
+
+        // Body: 2 APs @ FC 6 = 6
+        // Dex: 3 APs @ FC 7 = 14
+        // Total attributes = 20
+        expect(gadget.system.gadgetPointBudget.attributesCost).toBe(20);
+    });
+});

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -718,12 +718,12 @@ export class MEGSItem extends Item {
         if (systemData.attributes) {
             for (const [key, attr] of Object.entries(systemData.attributes)) {
                 if (attr.value > 0) {
-                    let fc = attr.factorCost + reliabilityMod;
+                    let fc = (Number(attr.factorCost) || 0) + reliabilityMod;
                     if (attr.alwaysSubstitute) fc += 2;
                     if (key === 'body' && this._toBoolean(systemData.hasHardenedDefenses)) {
                         fc += 2;
                     }
-                    fc = Math.max(1, fc);
+                    fc = Math.min(10, Math.max(1, fc));
                     attributesCost += this._getAPCost(attr.value, fc);
                 }
             }
@@ -981,7 +981,7 @@ export class MEGSItem extends Item {
                         if (game.settings.get('megs', 'debugLogging')) {
                             console.log(`  ${key.toUpperCase()}: value=${attr.value}, base FC=${attr.factorCost}`);
                         }
-                        let fc = attr.factorCost + reliabilityMod;
+                        let fc = (Number(attr.factorCost) || 0) + reliabilityMod;
                         if (game.settings.get('megs', 'debugLogging')) {
                             console.log(`    After reliability mod: FC=${fc}`);
                         }
@@ -1002,7 +1002,7 @@ export class MEGSItem extends Item {
                             }
                         }
 
-                        fc = Math.max(1, fc); // Minimum FC of 1
+                        fc = Math.min(10, Math.max(1, fc));
                         const attrCost = MEGS.getAPCost(attr.value, fc) || 0;
                         if (game.settings.get('megs', 'debugLogging')) {
                             console.log(`    Final: ${attr.value} APs @ FC ${fc} = ${attrCost} HP`);

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -973,14 +973,14 @@ Handlebars.registerHelper('getGadgetCostTooltip', function (gadget) {
     if (systemData.attributes) {
         for (const [key, attr] of Object.entries(systemData.attributes)) {
             if (attr.value > 0) {
-                let fc = attr.factorCost + reliabilityMod;
+                let fc = (Number(attr.factorCost) || 0) + reliabilityMod;
                 if (attr.alwaysSubstitute) {
                     fc += 2;
                 }
                 if (key === 'body' && (systemData.hasHardenedDefenses === true || systemData.hasHardenedDefenses === 'true')) {
                     fc += 2;
                 }
-                fc = Math.max(1, fc);
+                fc = Math.min(10, Math.max(1, fc));
                 attributesCost += MEGS.getAPCost(attr.value, fc) || 0;
             }
         }
@@ -1084,15 +1084,16 @@ Handlebars.registerHelper('getGadgetAttributeCost', function (aps, baseFc, relia
     aps = Number(aps) || 0;
     if (aps === 0) return 0;
 
+    baseFc = Number(baseFc) || 0;
     const table = { 0: 3, 2: 2, 3: 1, 5: 0, 7: -1, 9: -2, 11: -3 };
-    const reliability = CONFIG.reliabilityScores?.[reliabilityIndex] ?? 5;
+    const reliability = CONFIG.reliabilityScores?.[Number(reliabilityIndex)] ?? 5;
     const reliabilityMod = table[reliability] ?? 0;
 
     let fc = baseFc + reliabilityMod;
     if (attrKey === 'body' && (hasHardenedDefenses === true || hasHardenedDefenses === 'true')) {
         fc += 2;
     }
-    fc = Math.max(1, fc);
+    fc = Math.min(10, Math.max(1, fc));
 
     return MEGS.getAPCost(aps, fc) || 0;
 });
@@ -1283,6 +1284,17 @@ Handlebars.registerPartial('plusMinusInput', function (args) {
 /* -------------------------------------------- */
 
 Hooks.once('ready', async function () {
+    // Re-prepare gadget items now that CONFIG.apCostChart is guaranteed loaded
+    if (CONFIG.apCostChart?.chart) {
+        for (const actor of game.actors) {
+            for (const item of actor.items) {
+                if (item.type === 'gadget') {
+                    item.prepareDerivedData();
+                }
+            }
+        }
+    }
+
     // Log compendium pack loading information only if debug logging is enabled
     if (game.settings.get('megs', 'debugLogging')) {
         console.log('[MEGS] ===========================================');

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/255-gadget-builder-attribute-costs/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/255-gadget-builder-attribute-costs/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/255-gadget-builder-attribute-costs",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary
- Fix type coercion bug in `getGadgetAttributeCost` Handlebars helper where `baseFc` was not converted to a number, causing string concatenation with the reliability modifier (e.g., `"6" + 3 = "63"`) which exceeded the valid FC range and made `getAPCost` return 0
- Add `Math.min(10, ...)` FC clamping across all gadget cost calculations (helper, tooltip, `prepareDerivedData`, `_calculateGadgetPointBudget`) to prevent edge cases like Body + Hardened Defenses + R#0 from exceeding the chart range
- Re-prepare gadget items in the `ready` hook to ensure budget totals use the loaded AP cost chart (which loads asynchronously in `init`)

## Test plan
- [x] All 112 Jest tests pass (including 3 new tests for FC clamping, string coercion, and budget verification)
- [x] Open a gadget builder sheet and verify individual attribute HP costs display correctly
- [x] Set Body to 2 at default reliability (R#0) and verify cost shows 9 HP (not 0)
- [x] Change reliability to R#5 and verify Body 2 shows 6 HP
- [x] Verify budget summary "Total Attributes Cost" matches sum of individual costs
- [x] Enable Hardened Defenses at R#0 and verify Body cost uses FC 10 (clamped) not 0
- [x] Incrementing attribute via plus button updates displayed cost

Fixes #255