### PR TITLE
Resolve SonarCloud maintainability issues from PR #252

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@
 - Replaced 12 direct `.hasOwnProperty()` calls with `Object.hasOwn()` across actor, item, and item-sheet modules (issue #217)
 - Cleaned up 249 lint findings across 16 files — `prefer-const`, `quotes`, `indent`, brace-style, unused variables/imports, URL quoting, hex shorthand (issue #218)
 - Replaced 37 global `parseInt()` calls with `Number.parseInt()` across 6 modules for consistency (issue #218)
+- Replaced 10 fixed `waitForTimeout` calls in sub-gadget E2E tests with condition-based waits (`waitForSelector`, `waitForFunction`) for less flaky, faster tests (issue #256)
+- Refactored `_categorizeItem` to accept a destructured object instead of 8 positional parameters (issue #256)
+- Replaced 2 `!x || x.prop` null checks with optional chaining (`x?.prop`) in gadget drop handlers (issue #256)
 
 ## 1.0.0 (February 1, 2026)
 

--- a/e2e/tests/sub-gadget.spec.mjs
+++ b/e2e/tests/sub-gadget.spec.mjs
@@ -37,7 +37,6 @@ async function createActorWithSubGadget(page, actorName) {
 }
 
 test.describe('Sub-gadget display and controls (#78)', () => {
-
     test('Sub-gadget appears indented under parent on Gadgets tab', async ({ page }) => {
         let actorId;
         try {
@@ -45,7 +44,7 @@ test.describe('Sub-gadget display and controls (#78)', () => {
             actorId = result.actorId;
 
             await openActorSheet(page, actorId, 'gadgets');
-            await page.waitForTimeout(500);
+            await page.waitForSelector(`.sub-gadget-row[data-item-id="${result.subGadgetId}"]`, { timeout: 5000 });
 
             const subRow = await page.$(`.sub-gadget-row[data-item-id="${result.subGadgetId}"]`);
             expect(subRow).not.toBeNull();
@@ -68,7 +67,7 @@ test.describe('Sub-gadget display and controls (#78)', () => {
             actorId = result.actorId;
 
             await openActorSheet(page, actorId, 'gadgets');
-            await page.waitForTimeout(500);
+            await page.waitForSelector(`.sub-gadget-row[data-item-id="${result.subGadgetId}"]`, { timeout: 5000 });
 
             await page.evaluate((subGadgetId) => {
                 const row = document.querySelector(`.sub-gadget-row[data-item-id="${subGadgetId}"]`);
@@ -76,7 +75,7 @@ test.describe('Sub-gadget display and controls (#78)', () => {
                 if (editBtn) editBtn.click();
             }, result.subGadgetId);
 
-            await page.waitForTimeout(1000);
+            await page.waitForSelector('.sheet.item', { timeout: 5000 });
 
             const sheetTitle = await page.evaluate(() => {
                 const itemSheet = document.querySelector('.sheet.item');
@@ -102,7 +101,7 @@ test.describe('Sub-gadget display and controls (#78)', () => {
             actorId = result.actorId;
 
             await openActorSheet(page, actorId, 'gadgets');
-            await page.waitForTimeout(500);
+            await page.waitForSelector(`.sub-gadget-row[data-item-id="${result.subGadgetId}"]`, { timeout: 5000 });
 
             let subRow = await page.$(`.sub-gadget-row[data-item-id="${result.subGadgetId}"]`);
             expect(subRow).not.toBeNull();
@@ -125,7 +124,11 @@ test.describe('Sub-gadget display and controls (#78)', () => {
                 if (buttons.length > 0) buttons[0].click();
             });
 
-            await page.waitForTimeout(1500);
+            await page.waitForFunction(
+                (id) => !document.querySelector(`.sub-gadget-row[data-item-id="${id}"]`),
+                { timeout: 5000 },
+                result.subGadgetId
+            );
 
             subRow = await page.$(`.sub-gadget-row[data-item-id="${result.subGadgetId}"]`);
             expect(subRow).toBeNull();
@@ -172,7 +175,7 @@ test.describe('Sub-gadget display and controls (#78)', () => {
             }, actorId);
 
             await openActorSheet(page, actorId, 'gadgets');
-            await page.waitForTimeout(500);
+            await page.waitForSelector(`.sub-gadget-row[data-item-id="${ids.subGadgetId}"]`, { timeout: 5000 });
 
             const hasRollBtn = await page.evaluate((subGadgetId) => {
                 const row = document.querySelector(`.sub-gadget-row[data-item-id="${subGadgetId}"]`);
@@ -221,7 +224,7 @@ test.describe('Sub-gadget display and controls (#78)', () => {
             }, actorId);
 
             await openActorSheet(page, actorId, 'gadgets');
-            await page.waitForTimeout(500);
+            await page.waitForSelector('.tab.gadgets .item-row', { timeout: 5000 });
 
             // Programmatically set parent to simulate the drop
             const result = await page.evaluate(async (actorId) => {
@@ -233,7 +236,7 @@ test.describe('Sub-gadget display and controls (#78)', () => {
                 return { parentId: batsuit.id, childId: grapple.id };
             }, actorId);
 
-            await page.waitForTimeout(1000);
+            await page.waitForSelector(`.sub-gadget-row[data-item-id="${result.childId}"]`, { timeout: 5000 });
 
             const subRow = await page.$(`.sub-gadget-row[data-item-id="${result.childId}"]`);
             expect(subRow).not.toBeNull();
@@ -250,7 +253,7 @@ test.describe('Sub-gadget display and controls (#78)', () => {
             actorId = result.actorId;
 
             await openActorSheet(page, actorId, 'gadgets');
-            await page.waitForTimeout(500);
+            await page.waitForSelector(`.sub-gadget-row[data-item-id="${result.subGadgetId}"]`, { timeout: 5000 });
 
             // Verify it's a sub-gadget first
             let subRow = await page.$(`.sub-gadget-row[data-item-id="${result.subGadgetId}"]`);
@@ -264,7 +267,11 @@ test.describe('Sub-gadget display and controls (#78)', () => {
                 actor.sheet.render(false);
             }, { actorId, subGadgetId: result.subGadgetId });
 
-            await page.waitForTimeout(1000);
+            await page.waitForFunction(
+                (id) => !document.querySelector(`.sub-gadget-row[data-item-id="${id}"]`),
+                { timeout: 5000 },
+                result.subGadgetId
+            );
 
             // Should no longer be a sub-gadget row
             subRow = await page.$(`.sub-gadget-row[data-item-id="${result.subGadgetId}"]`);

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -434,7 +434,7 @@ export class MEGSActorSheet extends ActorSheet {
         // Iterate through items, allocating to containers
         context.items.forEach((i) => {
             i.img = i.img || Item.DEFAULT_ICON;
-            this._categorizeItem(i, powers, skills, advantages, drawbacks, subskills, gadgets, subGadgets);
+            this._categorizeItem(i, { powers, skills, advantages, drawbacks, subskills, gadgets, subGadgets });
         });
 
         // Add skills from linked gadget (for vehicles/locations)
@@ -509,7 +509,7 @@ export class MEGSActorSheet extends ActorSheet {
         await super._render(force, options);
     }
 
-    _categorizeItem(i, powers, skills, advantages, drawbacks, subskills, gadgets, subGadgets) {
+    _categorizeItem(i, { powers, skills, advantages, drawbacks, subskills, gadgets, subGadgets }) {
         const isChild = !!i.system.parent;
 
         if (i.type === MEGS.itemTypes.subskill) {
@@ -983,7 +983,7 @@ export class MEGSActorSheet extends ActorSheet {
         if (data.type !== 'Item') return;
 
         const droppedItem = await Item.implementation.fromDropData(data);
-        if (!droppedItem || droppedItem.type !== MEGS.itemTypes.gadget) return;
+        if (droppedItem?.type !== MEGS.itemTypes.gadget) return;
 
         const isOnActor = droppedItem.parent?.id === this.actor.id;
         if (!isOnActor) return;
@@ -1018,7 +1018,7 @@ export class MEGSActorSheet extends ActorSheet {
         if (data.type !== 'Item') return;
 
         const droppedItem = await Item.implementation.fromDropData(data);
-        if (!droppedItem || droppedItem.type !== MEGS.itemTypes.gadget) return;
+        if (droppedItem?.type !== MEGS.itemTypes.gadget) return;
 
         const isOnActor = droppedItem.parent?.id === this.actor.id;
         if (!isOnActor) return;

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/256-sonarcloud-maintainability/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/256-sonarcloud-maintainability/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/256-sonarcloud-maintainability",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary

- Replace 10 fixed `waitForTimeout` calls in sub-gadget E2E tests with condition-based waits (`waitForSelector`, `waitForFunction`) — less flaky, faster execution
- Refactor `_categorizeItem` to accept a destructured object parameter instead of 8 positional args (S107)
- Apply optional chaining in 2 gadget drop handlers (S6582)
- Fix pre-existing `padded-blocks` lint warning in test file

## Test plan

- [x] ESLint passes on changed files
- [x] All 109 Jest unit tests pass
- [x] E2E sub-gadget tests pass with the new condition-based waits (11/11, 3.1m)

Fixes #256