### PR TITLE
Upgrade to Foundry VTT v14 compatibility

### DIFF
--- a/css/megs.css
+++ b/css/megs.css
@@ -1477,7 +1477,8 @@ details summary.no-arrow {
   background-color: #fff;
   font-family: "Roboto", sans-serif;
 }
-.megs.dialog .dialog-buttons {
+.megs.dialog .dialog-buttons,
+.megs.dialog .form-footer {
   position: sticky;
   bottom: 0;
   background-color: #ddebf6;
@@ -1485,7 +1486,8 @@ details summary.no-arrow {
   padding: 10px;
   z-index: 10;
 }
-.megs.dialog .dialog-buttons button {
+.megs.dialog .dialog-buttons button,
+.megs.dialog .form-footer button {
   background-color: #1f5079;
   color: #fff;
   border: 2px solid #1f5079;
@@ -1497,11 +1499,13 @@ details summary.no-arrow {
   cursor: pointer;
   transition: all 0.2s;
 }
-.megs.dialog .dialog-buttons button:hover {
+.megs.dialog .dialog-buttons button:hover,
+.megs.dialog .form-footer button:hover {
   background-color: #5fa2d9;
   border-color: #5fa2d9;
 }
-.megs.dialog .dialog-buttons button:active {
+.megs.dialog .dialog-buttons button:active,
+.megs.dialog .form-footer button:active {
   background-color: #153550; /* stylelint-disable-line scss/no-global-function-names */
 }
 
@@ -1590,6 +1594,8 @@ details summary.no-arrow {
   padding: 8px 4px;
   font-size: 14px;
   outline: none;
+  background-color: #fff;
+  color: #1f5079;
 }
 .megs-dialog .quantity .input-box::-webkit-inner-spin-button, .megs-dialog .quantity .input-box::-webkit-outer-spin-button {
   -webkit-appearance: none;

--- a/e2e/fixtures/foundry-test.mjs
+++ b/e2e/fixtures/foundry-test.mjs
@@ -23,9 +23,13 @@ export const test = base.extend({
         await use(workerPage);
         await workerPage.evaluate(() => {
             Object.values(ui.windows).forEach(w => w.close());
+            for (const d of document.querySelectorAll('dialog[open]')) {
+                d.close();
+            }
         }).catch(() => {});
         await workerPage.waitForFunction(
-            () => Object.keys(ui.windows).length === 0,
+            () => Object.keys(ui.windows).length === 0
+                && !document.querySelector('dialog[open]'),
             null,
             { timeout: 5000 }
         ).catch(() => {});

--- a/e2e/fixtures/roll-helpers.mjs
+++ b/e2e/fixtures/roll-helpers.mjs
@@ -24,6 +24,12 @@ export async function getRollDialogValues(page) {
 
 export async function closeRollDialog(page) {
     await page.evaluate(() => {
+        const dialog = document.querySelector('dialog.dialog, .dialog');
+        const closeBtn = dialog?.querySelector('button[data-action="close"]');
+        if (closeBtn) {
+            const form = closeBtn.closest('form');
+            if (form) { form.requestSubmit(closeBtn); return; }
+        }
         for (const btn of document.querySelectorAll('.dialog button')) {
             if (btn.textContent.includes('Close')) { btn.click(); return; }
         }
@@ -37,6 +43,12 @@ export async function closeRollDialog(page) {
 
 export async function submitRollDialog(page, beforeCount) {
     await page.evaluate(() => {
+        const dialog = document.querySelector('dialog.dialog, .dialog');
+        const submitBtn = dialog?.querySelector('button[data-action="submit"]');
+        if (submitBtn) {
+            const form = submitBtn.closest('form');
+            if (form) { form.requestSubmit(submitBtn); return; }
+        }
         for (const btn of document.querySelectorAll('.dialog button')) {
             const text = btn.textContent.trim();
             if (text === 'Roll' || text === 'Submit') { btn.click(); return; }
@@ -69,18 +81,32 @@ export async function selectPickerOptionAndRoll(page, index) {
     await page.evaluate((idx) => {
         const radios = document.querySelectorAll('.dialog .megs-dialog input[name="selectedOption"]');
         if (radios[idx]) radios[idx].checked = true;
+        const dialog = document.querySelector('dialog.dialog, .dialog');
+        const rollBtn = dialog?.querySelector('button[data-action="roll"]');
+        if (rollBtn) {
+            const form = rollBtn.closest('form');
+            if (form) { form.requestSubmit(rollBtn); return; }
+        }
+        for (const btn of dialog.querySelectorAll('button')) {
+            if (btn.textContent.trim().includes('Roll')) { btn.click(); return; }
+        }
     }, index);
-    await page.click('.dialog button:has-text("Roll")');
     await page.waitForSelector('.dialog .megs-dialog #actionValue', { timeout: 5000 });
 }
 
 export async function cancelPickerDialog(page) {
     await page.evaluate(() => {
+        const dialog = document.querySelector('dialog.dialog, .dialog');
+        const cancelBtn = dialog?.querySelector('button[data-action="cancel"], button[data-action="close"]');
+        if (cancelBtn) {
+            const form = cancelBtn.closest('form');
+            if (form) { form.requestSubmit(cancelBtn); return; }
+            cancelBtn.click();
+            return;
+        }
         for (const btn of document.querySelectorAll('.dialog button')) {
             if (btn.textContent.includes('Close')) { btn.click(); return; }
         }
-        const x = document.querySelector('.dialog .header-button.close');
-        if (x) x.click();
     });
     await page.waitForFunction(
         () => !document.querySelector('.dialog .megs-dialog input[name="selectedOption"]'),
@@ -162,6 +188,12 @@ export async function fillRollDialog(page, { av, ev, ov, rv, maneuver, resultShi
 /** Click Submit in the roll dialog without waiting for a chat message. */
 export async function clickRollDialogSubmit(page) {
     await page.evaluate(() => {
+        const dialog = document.querySelector('dialog.dialog, .dialog');
+        const submitBtn = dialog?.querySelector('button[data-action="submit"]');
+        if (submitBtn) {
+            const form = submitBtn.closest('form');
+            if (form) { form.requestSubmit(submitBtn); return; }
+        }
         for (const btn of document.querySelectorAll('.dialog button')) {
             const text = btn.textContent.trim();
             if (text === 'Roll' || text === 'Submit') { btn.click(); return; }
@@ -175,21 +207,27 @@ export async function clickRollDialogSubmit(page) {
  * Waits for the dialog to appear, then clicks Yes or No.
  */
 export async function answerDoublesPrompt(page, continueRolling) {
-    // Answered dialogs are tagged with data-e2e-answered so consecutive
-    // prompts are not confused with a prior dialog that is still closing.
     await page.waitForFunction(
-        () => [...document.querySelectorAll('.dialog')].some(d =>
+        () => [...document.querySelectorAll('dialog.dialog, .dialog')].some(d =>
             !d.dataset.e2eAnswered &&
-            [...d.querySelectorAll('.window-title, h4')].some(el => el.textContent.includes('Continue Rolling'))),
+            [...d.querySelectorAll('.window-title, .window-header h1, h4')].some(el => el.textContent.includes('Continue Rolling'))),
         null,
         { timeout: 10000 }
     );
     await page.evaluate((yes) => {
-        const dialog = [...document.querySelectorAll('.dialog')].find(d =>
+        const dialog = [...document.querySelectorAll('dialog.dialog, .dialog')].find(d =>
             !d.dataset.e2eAnswered &&
-            [...d.querySelectorAll('.window-title, h4')].some(el => el.textContent.includes('Continue Rolling')));
+            [...d.querySelectorAll('.window-title, .window-header h1, h4')].some(el => el.textContent.includes('Continue Rolling')));
         if (!dialog) throw new Error('Doubles confirm dialog not found');
         dialog.dataset.e2eAnswered = '1';
+        const action = yes ? 'yes' : 'no';
+        const actionBtn = dialog.querySelector(`button[data-action="${action}"]`);
+        if (actionBtn) {
+            const form = actionBtn.closest('form');
+            if (form) { form.requestSubmit(actionBtn); return; }
+            actionBtn.click();
+            return;
+        }
         const label = yes ? 'Yes' : 'No';
         for (const btn of dialog.querySelectorAll('button')) {
             if (btn.textContent.trim().includes(label)) { btn.click(); return; }

--- a/e2e/fixtures/roll-helpers.mjs
+++ b/e2e/fixtures/roll-helpers.mjs
@@ -28,7 +28,7 @@ export async function closeRollDialog(page) {
         const closeBtn = dialog?.querySelector('button[data-action="close"]');
         if (closeBtn) {
             const form = closeBtn.closest('form');
-            if (form) { form.requestSubmit(closeBtn); return; }
+            if (form && closeBtn.type === 'submit') { form.requestSubmit(closeBtn); return; }
         }
         for (const btn of document.querySelectorAll('.dialog button')) {
             if (btn.textContent.includes('Close')) { btn.click(); return; }
@@ -47,7 +47,7 @@ export async function submitRollDialog(page, beforeCount) {
         const submitBtn = dialog?.querySelector('button[data-action="submit"]');
         if (submitBtn) {
             const form = submitBtn.closest('form');
-            if (form) { form.requestSubmit(submitBtn); return; }
+            if (form && submitBtn.type === 'submit') { form.requestSubmit(submitBtn); return; }
         }
         for (const btn of document.querySelectorAll('.dialog button')) {
             const text = btn.textContent.trim();
@@ -85,7 +85,7 @@ export async function selectPickerOptionAndRoll(page, index) {
         const rollBtn = dialog?.querySelector('button[data-action="roll"]');
         if (rollBtn) {
             const form = rollBtn.closest('form');
-            if (form) { form.requestSubmit(rollBtn); return; }
+            if (form && rollBtn.type === 'submit') { form.requestSubmit(rollBtn); return; }
         }
         for (const btn of dialog.querySelectorAll('button')) {
             if (btn.textContent.trim().includes('Roll')) { btn.click(); return; }
@@ -100,7 +100,7 @@ export async function cancelPickerDialog(page) {
         const cancelBtn = dialog?.querySelector('button[data-action="cancel"], button[data-action="close"]');
         if (cancelBtn) {
             const form = cancelBtn.closest('form');
-            if (form) { form.requestSubmit(cancelBtn); return; }
+            if (form && cancelBtn.type === 'submit') { form.requestSubmit(cancelBtn); return; }
             cancelBtn.click();
             return;
         }
@@ -192,7 +192,7 @@ export async function clickRollDialogSubmit(page) {
         const submitBtn = dialog?.querySelector('button[data-action="submit"]');
         if (submitBtn) {
             const form = submitBtn.closest('form');
-            if (form) { form.requestSubmit(submitBtn); return; }
+            if (form && submitBtn.type === 'submit') { form.requestSubmit(submitBtn); return; }
         }
         for (const btn of document.querySelectorAll('.dialog button')) {
             const text = btn.textContent.trim();
@@ -224,7 +224,7 @@ export async function answerDoublesPrompt(page, continueRolling) {
         const actionBtn = dialog.querySelector(`button[data-action="${action}"]`);
         if (actionBtn) {
             const form = actionBtn.closest('form');
-            if (form) { form.requestSubmit(actionBtn); return; }
+            if (form && actionBtn.type === 'submit') { form.requestSubmit(actionBtn); return; }
             actionBtn.click();
             return;
         }

--- a/e2e/fixtures/roll-helpers.mjs
+++ b/e2e/fixtures/roll-helpers.mjs
@@ -8,7 +8,7 @@
 }
 
 export async function waitForRollDialog(page) {
-    await page.waitForSelector('.dialog .megs-dialog #actionValue', { timeout: 5000 });
+    await page.waitForSelector('dialog.dialog[open] .megs-dialog #actionValue, .dialog .megs-dialog #actionValue', { timeout: 10000 });
 }
 
 export async function getRollDialogValues(page) {
@@ -99,21 +99,23 @@ export async function selectPickerOptionAndRoll(page, index) {
 }
 
 export async function cancelPickerDialog(page) {
-    await page.evaluate(() => {
-        const dialog = document.querySelector('dialog.dialog, .dialog');
-        const cancelBtn = dialog?.querySelector('button[data-action="cancel"], button[data-action="close"]');
-        if (cancelBtn) {
-            const form = cancelBtn.closest('form');
-            if (form && cancelBtn.type === 'submit') { form.requestSubmit(cancelBtn); return; }
-            cancelBtn.click();
-            return;
-        }
-        for (const btn of document.querySelectorAll('.dialog button')) {
-            if (btn.textContent.includes('Close')) { btn.click(); return; }
-        }
-    });
+    const cancelBtn = page.locator('dialog.dialog[open] footer button[data-action="cancel"], dialog.dialog[open] footer button[data-action="close"]').first();
+    if (await cancelBtn.count()) {
+        await cancelBtn.click({ timeout: 3000 });
+    } else {
+        await page.evaluate(() => {
+            for (const btn of document.querySelectorAll('.dialog button')) {
+                if (btn.textContent.includes('Close')) { btn.click(); return; }
+            }
+        });
+    }
     await page.waitForFunction(
-        () => !document.querySelector('.dialog .megs-dialog input[name="selectedOption"]'),
+        () => {
+            const el = document.querySelector('.dialog .megs-dialog input[name="selectedOption"]');
+            if (!el) return true;
+            const dlg = el.closest('dialog');
+            return dlg && !dlg.open;
+        },
         null,
         { timeout: 5000 }
     );

--- a/e2e/fixtures/roll-helpers.mjs
+++ b/e2e/fixtures/roll-helpers.mjs
@@ -23,19 +23,23 @@ export async function getRollDialogValues(page) {
 }
 
 export async function closeRollDialog(page) {
-    await page.evaluate(() => {
-        const dialog = document.querySelector('dialog.dialog, .dialog');
-        const closeBtn = dialog?.querySelector('button[data-action="close"]');
-        if (closeBtn) {
-            const form = closeBtn.closest('form');
-            if (form && closeBtn.type === 'submit') { form.requestSubmit(closeBtn); return; }
-        }
-        for (const btn of document.querySelectorAll('.dialog button')) {
-            if (btn.textContent.includes('Close')) { btn.click(); return; }
-        }
-    });
+    const closeBtn = page.locator('dialog.dialog[open] footer button[data-action="close"]').first();
+    if (await closeBtn.count()) {
+        await closeBtn.click({ timeout: 3000 });
+    } else {
+        await page.evaluate(() => {
+            for (const btn of document.querySelectorAll('.dialog button')) {
+                if (btn.textContent.includes('Close')) { btn.click(); return; }
+            }
+        });
+    }
     await page.waitForFunction(
-        () => !document.querySelector('.dialog .megs-dialog #actionValue'),
+        () => {
+            const el = document.querySelector('.dialog .megs-dialog #actionValue');
+            if (!el) return true;
+            const dlg = el.closest('dialog');
+            return dlg && !dlg.open;
+        },
         null,
         { timeout: 5000 }
     );

--- a/e2e/fixtures/test-data.mjs
+++ b/e2e/fixtures/test-data.mjs
@@ -225,13 +225,21 @@ export async function closeAllWindows(page) {
         for (const w of Object.values(ui.windows)) {
             try { await w.close({ force: true }); } catch { /* mid-render close can throw */ }
         }
+        for (const d of document.querySelectorAll('dialog[open]')) {
+            d.close();
+        }
     });
     await forceCloseAll();
     try {
-        await page.waitForFunction(() => Object.keys(ui.windows).length === 0, null, { timeout: 5000 });
+        await page.waitForFunction(
+            () => Object.keys(ui.windows).length === 0 && !document.querySelector('dialog[open]'),
+            null, { timeout: 5000 }
+        );
     } catch {
-        // A window re-rendered while closing; one retry settles it
         await forceCloseAll();
-        await page.waitForFunction(() => Object.keys(ui.windows).length === 0, null, { timeout: 5000 });
+        await page.waitForFunction(
+            () => Object.keys(ui.windows).length === 0 && !document.querySelector('dialog[open]'),
+            null, { timeout: 5000 }
+        );
     }
 }

--- a/e2e/tests/active-effects.spec.mjs
+++ b/e2e/tests/active-effects.spec.mjs
@@ -25,7 +25,7 @@ test.describe('Active Effects (#226 cat 10)', () => {
                 const actor = game.actors.get(id);
                 const [created] = await actor.createEmbeddedDocuments('ActiveEffect', [{
                     name: 'Blessing',
-                    icon: 'icons/svg/aura.svg',
+                    img: 'icons/svg/aura.svg',
                     changes: [{ key: 'system.attributes.str.value', mode: 2, value: '2' }],
                 }]);
                 return { id: created.id, name: created.name, count: actor.effects.size };
@@ -45,7 +45,7 @@ test.describe('Active Effects (#226 cat 10)', () => {
             const states = await page.evaluate(async (id) => {
                 const actor = game.actors.get(id);
                 const [effect] = await actor.createEmbeddedDocuments('ActiveEffect', [{
-                    name: 'Slow', icon: 'icons/svg/anchor.svg',
+                    name: 'Slow', img: 'icons/svg/anchor.svg',
                 }]);
                 const initial = effect.disabled;
                 await effect.update({ disabled: true });
@@ -70,9 +70,9 @@ test.describe('Active Effects (#226 cat 10)', () => {
             const categories = await page.evaluate(async (id) => {
                 const actor = game.actors.get(id);
                 const [temporary, passive, inactive] = await actor.createEmbeddedDocuments('ActiveEffect', [
-                    { name: 'Stunned', icon: 'icons/svg/daze.svg', duration: { rounds: 2 } },
-                    { name: 'Tough', icon: 'icons/svg/shield.svg' },
-                    { name: 'Dormant', icon: 'icons/svg/sleep.svg', disabled: true },
+                    { name: 'Stunned', img: 'icons/svg/daze.svg', duration: { rounds: 2 } },
+                    { name: 'Tough', img: 'icons/svg/shield.svg' },
+                    { name: 'Dormant', img: 'icons/svg/sleep.svg', disabled: true },
                 ]);
                 return {
                     temporaryIsTemporary: temporary.isTemporary,
@@ -96,7 +96,7 @@ test.describe('Active Effects (#226 cat 10)', () => {
             const result = await page.evaluate(async (id) => {
                 const actor = game.actors.get(id);
                 const [effect] = await actor.createEmbeddedDocuments('ActiveEffect', [{
-                    name: 'Doomed', icon: 'icons/svg/skull.svg',
+                    name: 'Doomed', img: 'icons/svg/skull.svg',
                 }]);
                 const beforeDelete = actor.effects.size;
                 await effect.delete();

--- a/e2e/tests/active-effects.spec.mjs
+++ b/e2e/tests/active-effects.spec.mjs
@@ -69,11 +69,14 @@ test.describe('Active Effects (#226 cat 10)', () => {
             actorId = await createHeroActor(page, prefixName('AE_Categories'));
             const categories = await page.evaluate(async (id) => {
                 const actor = game.actors.get(id);
-                const [temporary, passive, inactive] = await actor.createEmbeddedDocuments('ActiveEffect', [
+                const effects = await actor.createEmbeddedDocuments('ActiveEffect', [
                     { name: 'Stunned', img: 'icons/svg/daze.svg', duration: { rounds: 2 } },
                     { name: 'Tough', img: 'icons/svg/shield.svg' },
                     { name: 'Dormant', img: 'icons/svg/sleep.svg', disabled: true },
                 ]);
+                const temporary = effects.find(e => e.name === 'Stunned');
+                const passive = effects.find(e => e.name === 'Tough');
+                const inactive = effects.find(e => e.name === 'Dormant');
                 return {
                     temporaryIsTemporary: temporary.isTemporary,
                     passiveIsTemporary: passive.isTemporary,

--- a/e2e/tests/gadget-rolling.spec.mjs
+++ b/e2e/tests/gadget-rolling.spec.mjs
@@ -104,7 +104,7 @@ async function clickGadgetRollButton(page, gadgetName) {
         return false;
     }, gadgetName);
     if (!clicked) throw new Error(`Could not click roll button for "${gadgetName}"`);
-    await page.waitForSelector('.dialog', { timeout: 5000 });
+    await page.waitForSelector('dialog.dialog[open], .dialog .megs-dialog', { timeout: 10000 });
 }
 
 /**
@@ -571,7 +571,7 @@ test.describe('Gadget Rolling (#17)', () => {
                 gadget.roll();
             }, { actorId, gadgetId });
 
-            await page.waitForSelector('.dialog', { timeout: 5000 });
+            await page.waitForSelector('dialog.dialog[open], .dialog .megs-dialog', { timeout: 10000 });
 
             const pickerOpen = await isPickerDialogOpen(page);
             expect(pickerOpen).toBe(true);

--- a/e2e/tests/gadget-sheet-rolling.spec.mjs
+++ b/e2e/tests/gadget-sheet-rolling.spec.mjs
@@ -321,6 +321,7 @@ test.describe('Gadget Sheet Rolling (#13)', () => {
             await queueDice(page, [6, 3]);
 
             await openGadgetSheet(page, actorId, gadgetId);
+            await page.waitForTimeout(500);
             const beforeCount = await getChatMessageCount(page);
 
             await clickGadgetSheetRollButton(page);

--- a/e2e/tests/gadget-sheet-rolling.spec.mjs
+++ b/e2e/tests/gadget-sheet-rolling.spec.mjs
@@ -321,7 +321,11 @@ test.describe('Gadget Sheet Rolling (#13)', () => {
             await queueDice(page, [6, 3]);
 
             await openGadgetSheet(page, actorId, gadgetId);
-            await page.waitForTimeout(500);
+            await page.waitForFunction(
+                () => !document.querySelector('dialog[open]'),
+                null,
+                { timeout: 5000 }
+            ).catch(() => {});
             const beforeCount = await getChatMessageCount(page);
 
             await clickGadgetSheetRollButton(page);

--- a/e2e/tests/sub-gadget.spec.mjs
+++ b/e2e/tests/sub-gadget.spec.mjs
@@ -112,9 +112,17 @@ test.describe('Sub-gadget display and controls (#78)', () => {
                 if (deleteBtn) deleteBtn.click();
             }, result.subGadgetId);
 
-            await page.waitForSelector('.dialog .dialog-buttons', { timeout: 5000 });
+            await page.waitForSelector('.dialog .form-footer, .dialog .dialog-buttons', { timeout: 5000 });
             await page.evaluate(() => {
-                const buttons = document.querySelectorAll('.dialog .dialog-buttons button');
+                const dialog = document.querySelector('dialog.dialog, .dialog');
+                const yesBtn = dialog?.querySelector('button[data-action="yes"]');
+                if (yesBtn) {
+                    const form = yesBtn.closest('form');
+                    if (form && yesBtn.type === 'submit') { form.requestSubmit(yesBtn); return; }
+                    yesBtn.click();
+                    return;
+                }
+                const buttons = dialog?.querySelectorAll('.form-footer button, .dialog-buttons button') ?? [];
                 for (const btn of buttons) {
                     if (btn.textContent.trim().match(/yes|delete|ok/i)) {
                         btn.click();

--- a/e2e/tests/sub-gadget.spec.mjs
+++ b/e2e/tests/sub-gadget.spec.mjs
@@ -134,8 +134,8 @@ test.describe('Sub-gadget display and controls (#78)', () => {
 
             await page.waitForFunction(
                 (id) => !document.querySelector(`.sub-gadget-row[data-item-id="${id}"]`),
-                { timeout: 5000 },
-                result.subGadgetId
+                result.subGadgetId,
+                { timeout: 10000 }
             );
 
             subRow = await page.$(`.sub-gadget-row[data-item-id="${result.subGadgetId}"]`);
@@ -277,8 +277,8 @@ test.describe('Sub-gadget display and controls (#78)', () => {
 
             await page.waitForFunction(
                 (id) => !document.querySelector(`.sub-gadget-row[data-item-id="${id}"]`),
-                { timeout: 5000 },
-                result.subGadgetId
+                result.subGadgetId,
+                { timeout: 10000 }
             );
 
             // Should no longer be a sub-gadget row

--- a/module/__mocks__/foundry.mjs
+++ b/module/__mocks__/foundry.mjs
@@ -289,26 +289,35 @@ async function _loadData(jsonPath) {
     }
 }
 
-export class YesDialog {
+export class YesDialogV2 {
     static confirm() {
-        return true;
+        return Promise.resolve(true);
+    }
+
+    static wait() {
+        return Promise.resolve(null);
     }
 }
 
-export class NoDialog {
+export class NoDialogV2 {
     static confirm() {
-        return false;
+        return Promise.resolve(false);
+    }
+
+    static wait() {
+        return Promise.resolve(null);
     }
 }
 
-export class HandleRollDialog {
+export class HandleRollDialogV2 {
     static confirm() {
-        return true;
+        return Promise.resolve(true);
+    }
+
+    static wait() {
+        return Promise.resolve(null);
     }
 }
-
-// }
-// global.Dialog = Dialog
 
 /**
  * Localization
@@ -389,11 +398,10 @@ global.ui = {
 };
 
 /**
- * Global helper functions function
+ * Foundry v14 utility functions (namespaced under foundry.utils)
  */
 
-// Foundry's implementation of getType
-global.getType = function (token) {
+function _getType(token) {
     const tof = typeof token;
     if (tof === 'object') {
         if (token === null) return 'null';
@@ -403,14 +411,11 @@ global.getType = function (token) {
         else return 'Object';
     }
     return tof;
-};
+}
 
-// Foundry's implementation of setProperty
-global.setProperty = function (object, key, value) {
+function _setProperty(object, key, value) {
     let target = object;
     let changed = false;
-
-    // Convert the key to an object reference if it contains dot notation
     if (key.indexOf('.') !== -1) {
         const parts = key.split('.');
         key = parts.pop();
@@ -419,35 +424,37 @@ global.setProperty = function (object, key, value) {
             return o[i];
         }, object);
     }
-
-    // Update the target
     if (target[key] !== value) {
         changed = true;
         target[key] = value;
     }
-
-    // Return changed status
     return changed;
-};
+}
 
-// Foundry's implementation of expandObject
-global.expandObject = function (obj, _d = 0) {
+function _expandObject(obj, _d = 0) {
     const expanded = {};
     if (_d > 10) throw new Error('Maximum depth exceeded');
     for (let [k, v] of Object.entries(obj)) {
-        if (v instanceof Object && !Array.isArray(v)) v = global.expandObject(v, _d + 1);
-        global.setProperty(expanded, k, v);
+        if (v instanceof Object && !Array.isArray(v)) v = _expandObject(v, _d + 1);
+        _setProperty(expanded, k, v);
     }
     return expanded;
-};
+}
 
-// Foundry's implementation of duplicate
-global.duplicate = function (original) {
-    return JSON.parse(JSON.stringify(original));
-};
+function _deepClone(original) {
+    if (typeof original !== 'object' || original === null) return original;
+    if (original instanceof Date) return new Date(original);
+    if (original instanceof Array) return original.map(item => _deepClone(item));
+    if (original instanceof Set) return new Set([...original].map(item => _deepClone(item)));
+    if (original instanceof Map) return new Map([...original].map(([k, v]) => [_deepClone(k), _deepClone(v)]));
+    const clone = {};
+    for (const [k, v] of Object.entries(original)) {
+        clone[k] = _deepClone(v);
+    }
+    return clone;
+}
 
-// Foundry's implementation of mergeObject
-global.mergeObject = function (
+function _mergeObject(
     original,
     other = {},
     {
@@ -466,90 +473,74 @@ global.mergeObject = function (
     }
     const depth = _d + 1;
 
-    // Maybe copy the original data at depth 0
-    if (!inplace && _d === 0) original = global.duplicate(original);
+    if (!inplace && _d === 0) original = _deepClone(original);
 
-    // Enforce object expansion at depth 0
-    if (_d === 0 && Object.keys(original).some((k) => /\./.test(k))) { original = global.expandObject(original); }
-    if (_d === 0 && Object.keys(other).some((k) => /\./.test(k))) { other = global.expandObject(other); }
+    if (_d === 0 && Object.keys(original).some((k) => /\./.test(k))) { original = _expandObject(original); }
+    if (_d === 0 && Object.keys(other).some((k) => /\./.test(k))) { other = _expandObject(other); }
 
-    // Iterate over the other object
     for (let [k, v] of Object.entries(other)) {
-        const tv = global.getType(v);
+        const tv = _getType(v);
 
-        // Prepare to delete
         let toDelete = false;
         if (k.startsWith('-=')) {
             k = k.slice(2);
             toDelete = v === null;
         }
 
-        // Get the existing object
         let x = original[k];
         let has = Object.prototype.hasOwnProperty.call(original, k);
-        let tx = global.getType(x);
+        let tx = _getType(x);
 
-        // Ensure that inner objects exist
         if (!has && tv === 'Object') {
             x = original[k] = {};
             has = true;
             tx = 'Object';
         }
 
-        // Case 1 - Key exists
         if (has) {
-            // 1.1 - Recursively merge an inner object
             if (tv === 'Object' && tx === 'Object' && recursive) {
-                global.mergeObject(
-                    x,
-                    v,
-                    {
-                        insertKeys,
-                        insertValues,
-                        overwrite,
-                        inplace: true,
-                        enforceTypes,
-                    },
-                    depth
-                );
-
-                // 1.2 - Remove an existing key
+                _mergeObject(x, v, { insertKeys, insertValues, overwrite, inplace: true, enforceTypes }, depth);
             } else if (toDelete) {
                 delete original[k];
-
-                // 1.3 - Overwrite existing value
             } else if (overwrite) {
                 if (tx && tv !== tx && enforceTypes) {
                     throw new Error('Mismatched data types encountered during object merge.');
                 }
                 original[k] = v;
-
-                // 1.4 - Insert new value
             } else if (x === undefined && insertValues) {
                 original[k] = v;
             }
-
-            // Case 2 - Key does not exist
         } else if (!toDelete) {
             const canInsert = (depth === 1 && insertKeys) || (depth > 1 && insertValues);
             if (canInsert) original[k] = v;
         }
     }
 
-    // Return the object for use
     return original;
-};
-
-global.renderTemplate = async function (template, data) {};
+}
 
 /**
- * Foundry namespaced APIs (V13+)
+ * Foundry v14 namespaced APIs
  */
 global.foundry = {
     applications: {
         handlebars: {
             renderTemplate: async function (template, data) { }
+        },
+        api: {
+            DialogV2: {
+                confirm: jest.fn().mockResolvedValue(true),
+                wait: jest.fn().mockResolvedValue(null),
+                prompt: jest.fn().mockResolvedValue(null),
+            }
         }
+    },
+    utils: {
+        deepClone: _deepClone,
+        getType: _getType,
+        setProperty: _setProperty,
+        expandObject: _expandObject,
+        mergeObject: _mergeObject,
     }
 };
 

--- a/module/__tests__/dice.test.js
+++ b/module/__tests__/dice.test.js
@@ -1,4 +1,4 @@
-import { HandleRollDialog, NoDialog, YesDialog } from '../__mocks__/foundry.mjs';
+import { HandleRollDialogV2, NoDialogV2, YesDialogV2 } from '../__mocks__/foundry.mjs';
 import { MegsTableRolls, RollValues } from '../dice.mjs';
 
 import { jest } from '@jest/globals';
@@ -50,7 +50,7 @@ test('_handleRoll warns when more than one target is selected', async () => {
 test.todo('_handleTargetedRolls shows dialog with pre-filled values');
 
 test('_handleRolls should return 0 result APs for simplest fail path', () => {
-    global.Dialog = HandleRollDialog;
+    global.foundry.applications.api.DialogV2 = HandleRollDialogV2;
 
     const values = {
         label: 'Test',
@@ -83,7 +83,7 @@ test('_handleRolls should return 0 result APs for simplest fail path', () => {
 });
 
 // test('_handleRolls should return 1 result APs for simplest happy path', () => {
-//     global.Dialog = HandleRollDialog;
+//     global.foundry.applications.api.DialogV2 = HandleRollDialogV2;
 
 //     const values = {
 //         label: 'Test',
@@ -154,7 +154,7 @@ test('_rollDice should return if dice do not match', () => {
 });
 
 test('_rollDice should roll again if have matching dice on first roll and elect to roll again', () => {
-    global.Dialog = YesDialog;
+    global.foundry.applications.api.DialogV2 = YesDialogV2;
     const values = {
         label: 'Test',
         type: 'attribute',
@@ -191,7 +191,7 @@ test('_rollDice should roll again if have matching dice on first roll and elect 
 });
 
 test('_rollDice should roll again if have matching dice on first and second rolls and user elects to roll again both times', () => {
-    global.Dialog = YesDialog;
+    global.foundry.applications.api.DialogV2 = YesDialogV2;
     const values = {
         label: 'Test',
         type: 'attribute',
@@ -228,7 +228,7 @@ test('_rollDice should roll again if have matching dice on first and second roll
 });
 
 test('_rollDice should not roll again if have matching dice on first roll and user elects not to roll again', () => {
-    global.Dialog = NoDialog;
+    global.foundry.applications.api.DialogV2 = NoDialogV2;
     const values = {
         label: 'Test',
         type: 'attribute',
@@ -310,7 +310,7 @@ test('_rollDice should extract dice from initialRoll with terms structure', () =
 });
 
 test('_rollDice should show DSN for each pair when doubles are rolled', async () => {
-    global.Dialog = YesDialog;
+    global.foundry.applications.api.DialogV2 = YesDialogV2;
     const showForRollMock = jest.fn().mockResolvedValue(undefined);
     global.game.dice3d = { showForRoll: showForRollMock };
 
@@ -395,7 +395,7 @@ test('_rollDice should not call DSN showForRoll when no doubles', async () => {
 /*
 TODO fix
 test('_rollDice should not roll again if have matching dice on first roll and user elects not to roll again', () => {
-    global.Dialog = NoDialog;
+    global.foundry.applications.api.DialogV2 = NoDialogV2;
     const values = {
         label: 'Test',
         type: 'attribute',

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -100,21 +100,18 @@ export default class MEGSCombat extends Combat {
             updates.push({ _id: id, initiative: roll.total });
 
             // Construct chat message data
-            // eslint-disable-next-line no-undef
-            const messageData = foundry.utils.mergeObject(
-                {
-                    // eslint-disable-next-line no-undef
-                    speaker: ChatMessage.getSpeaker({
-                        actor: combatant.actor,
-                        token: combatant.token,
-                        alias: combatant.name,
-                    }),
-                    // eslint-disable-next-line no-undef
-                    flavor: game.i18n.format('COMBAT.RollsInitiative', { name: combatant.name }),
-                    flags: { 'core.initiativeRoll': true },
-                },
-                messageOptions
-            );
+            const messageData = {
+                // eslint-disable-next-line no-undef
+                speaker: ChatMessage.getSpeaker({
+                    actor: combatant.actor,
+                    token: combatant.token,
+                    alias: combatant.name,
+                }),
+                // eslint-disable-next-line no-undef
+                flavor: game.i18n.format('COMBAT.RollsInitiative', { name: combatant.name }),
+                flags: { 'core.initiativeRoll': true },
+                ...messageOptions,
+            };
             const chatData = await roll.toMessage(messageData, { create: false });
 
             // If the combatant is hidden, use a private roll unless an alternative rollMode was explicitly requested
@@ -163,30 +160,31 @@ export default class MEGSCombat extends Combat {
             label = combatantName + ' - ' + game.i18n.localize('MEGS.Initiative');
         }
 
-        return await new Promise((resolve, reject) => {
-            const d = new Dialog({
-                title: label,
-                content: dialogHtml,
-                buttons: {
-                    button2: {
-                        label: game.i18n.localize('MEGS.Close'),
-                        callback: (html) => {},
-                    },
-                    button1: {
-                        label: game.i18n.localize('MEGS.Roll'),
-                        callback: (html) => {
-                            const response = this._processHeroPointsEntry(
-                                html[0].querySelector('form')
-                            );
-                            resolve(response.hpSpentInitiative);
-                        },
+        const result = await foundry.applications.api.DialogV2.wait({
+            window: { title: label },
+            classes: ['megs', 'dialog'],
+            content: dialogHtml,
+            buttons: [
+                {
+                    action: 'roll',
+                    label: game.i18n.localize('MEGS.Roll'),
+                    default: true,
+                    callback: (event, button, dialog) => {
+                        const response = this._processHeroPointsEntry(
+                            dialog.querySelector('form')
+                        );
+                        return response.hpSpentInitiative;
                     },
                 },
-                default: 'button1',
-            }).render(true);
-        }).catch((err) => {
-            throw err;
+                {
+                    action: 'close',
+                    label: game.i18n.localize('MEGS.Close'),
+                    callback: () => 0,
+                },
+            ],
+            rejectClose: false,
         });
+        return result ?? 0;
     }
 
     /**

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -171,7 +171,7 @@ export default class MEGSCombat extends Combat {
                     default: true,
                     callback: (event, button, dialog) => {
                         const response = this._processHeroPointsEntry(
-                            dialog.querySelector('form')
+                            button.form
                         );
                         return response.hpSpentInitiative;
                     },

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -97,82 +97,23 @@ export class MegsTableRolls {
         // Manually enter OV and RV for target
         if (game.user.targets.size === 0) {
             console.info('Showing roll dialog from MegsTableRolls_handleRoll() without a target');
-            const template = 'systems/megs/templates/dialogs/rollDialog.hbs';
-            const maxHpToSpend = Math.min(currentHeroPoints, this.valueOrAps);
-            const data = {
-                valueOrAps: this.valueOrAps,
-                maxHpToSpend: maxHpToSpend,
-                isTargeted: false,
-                combatManeuvers: CONFIG.combatManeuvers,
-                actionValue: this.actionValue,
-                opposingValue: this.opposingValue,
-                effectValue: this.effectValue,
-                resistanceValue: this.resistanceValue,
-                isUnskilled: this.isUnskilled,
-            };
-            const dialogHtml = await this._renderTemplate(template, data);
-
-            const response = await foundry.applications.api.DialogV2.wait({
-                window: { title: label },
-                classes: ['megs', 'dialog'],
-                content: dialogHtml,
-                buttons: [
-                    {
-                        action: 'submit',
-                        label: game.i18n.localize('MEGS.Submit'),
-                        default: true,
-                        callback: (event, button, dialog) => {
-                            return this._processOpposingValuesEntry(
-                                button.form
-                            );
-                        },
-                    },
-                    {
-                        action: 'close',
-                        label: game.i18n.localize('MEGS.Close'),
-                    },
-                ],
-                rejectClose: false,
-            });
-            if (response) {
-                this.actionValue = response.actionValue;
-                this.effectValue = response.effectValue;
-                this.opposingValue = response.opposingValue;
-                this.resistanceValue = response.resistanceValue;
-                this.isUnskilled = response.isUnskilled;
-                await this._handleRolls(
-                    currentHeroPoints,
-                    maxHpToSpend,
-                    response.hpSpentAV,
-                    response.hpSpentEV,
-                    response.hpSpentOV,
-                    response.hpSpentRV,
-                    response.combatManeuver,
-                    response.resultColumnShifts,
-                    response.isUnskilled
-                );
-            }
+            await this._showRollDialogAndExecute(label, currentHeroPoints, false);
         } else if (game.user.targets.size > 1) {
             ui.notifications.warn(game.i18n.localize('MEGS.ErrorMessages.OnlyOneTarget'));
         } else {
             // use target token for OV and RV values
-            await this._handleTargetedRolls(label);
+            console.info('Showing roll dialog from MegsTableRolls._handleTargetedRolls()');
+            await this._showRollDialogAndExecute(this.label, currentHeroPoints, true);
         }
     }
 
-    /**
-     *
-     * @param {*} currentHeroPoints
-     */
-    async _handleTargetedRolls(currentHeroPoints) {
-        console.info('Showing roll dialog from MegsTableRolls._handleTargetedRolls()');
-
+    async _showRollDialogAndExecute(title, currentHeroPoints, isTargeted) {
         const template = 'systems/megs/templates/dialogs/rollDialog.hbs';
         const maxHpToSpend = Math.min(currentHeroPoints, this.valueOrAps);
         const data = {
             valueOrAps: this.valueOrAps,
             maxHpToSpend: maxHpToSpend,
-            isTargeted: true,
+            isTargeted,
             combatManeuvers: CONFIG.combatManeuvers,
             actionValue: this.actionValue,
             opposingValue: this.opposingValue,
@@ -183,7 +124,7 @@ export class MegsTableRolls {
         const dialogHtml = await this._renderTemplate(template, data);
 
         const response = await foundry.applications.api.DialogV2.wait({
-            window: { title: this.label },
+            window: { title },
             classes: ['megs', 'dialog'],
             content: dialogHtml,
             buttons: [
@@ -192,9 +133,7 @@ export class MegsTableRolls {
                     label: game.i18n.localize('MEGS.Submit'),
                     default: true,
                     callback: (event, button, dialog) => {
-                        return this._processOpposingValuesEntry(
-                            button.form
-                        );
+                        return this._processOpposingValuesEntry(button.form);
                     },
                 },
                 {

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -112,43 +112,46 @@ export class MegsTableRolls {
             };
             const dialogHtml = await this._renderTemplate(template, data);
 
-            new Dialog({
-                title: label,
+            const response = await foundry.applications.api.DialogV2.wait({
+                window: { title: label },
+                classes: ['megs', 'dialog'],
                 content: dialogHtml,
-                buttons: {
-                    button2: {
-                        label: game.i18n.localize('MEGS.Close'),
-                        callback: () => {},
-                    },
-                    button1: {
+                buttons: [
+                    {
+                        action: 'submit',
                         label: game.i18n.localize('MEGS.Submit'),
-                        callback: (html) => {
-                            const response = this._processOpposingValuesEntry(
-                                html[0].querySelector('form')
-                            );
-                            this.actionValue = response.actionValue;
-                            this.effectValue = response.effectValue;
-                            this.opposingValue = response.opposingValue;
-                            this.resistanceValue = response.resistanceValue;
-                            this.isUnskilled = response.isUnskilled;
-                            this._handleRolls(
-                                currentHeroPoints,
-                                maxHpToSpend,
-                                response.hpSpentAV,
-                                response.hpSpentEV,
-                                response.hpSpentOV,
-                                response.hpSpentRV,
-                                response.combatManeuver,
-                                response.resultColumnShifts,
-                                response.isUnskilled
+                        default: true,
+                        callback: (event, button, dialog) => {
+                            return this._processOpposingValuesEntry(
+                                dialog.querySelector('form')
                             );
                         },
                     },
-                },
-                default: 'button1',
-            }, {
-                classes: ['megs', 'dialog']
-            }).render(true);
+                    {
+                        action: 'close',
+                        label: game.i18n.localize('MEGS.Close'),
+                    },
+                ],
+                rejectClose: false,
+            });
+            if (response) {
+                this.actionValue = response.actionValue;
+                this.effectValue = response.effectValue;
+                this.opposingValue = response.opposingValue;
+                this.resistanceValue = response.resistanceValue;
+                this.isUnskilled = response.isUnskilled;
+                await this._handleRolls(
+                    currentHeroPoints,
+                    maxHpToSpend,
+                    response.hpSpentAV,
+                    response.hpSpentEV,
+                    response.hpSpentOV,
+                    response.hpSpentRV,
+                    response.combatManeuver,
+                    response.resultColumnShifts,
+                    response.isUnskilled
+                );
+            }
         } else if (game.user.targets.size > 1) {
             ui.notifications.warn(game.i18n.localize('MEGS.ErrorMessages.OnlyOneTarget'));
         } else {
@@ -179,43 +182,46 @@ export class MegsTableRolls {
         };
         const dialogHtml = await this._renderTemplate(template, data);
 
-        new Dialog({
-            title: this.label,
+        const response = await foundry.applications.api.DialogV2.wait({
+            window: { title: this.label },
+            classes: ['megs', 'dialog'],
             content: dialogHtml,
-            buttons: {
-                button2: {
-                    label: 'Close',
-                    callback: () => {},
-                },
-                button1: {
-                    label: 'Submit',
-                    callback: (html) => {
-                        const response = this._processOpposingValuesEntry(
-                            html[0].querySelector('form')
-                        );
-                        this.actionValue = response.actionValue;
-                        this.effectValue = response.effectValue;
-                        this.opposingValue = response.opposingValue;
-                        this.resistanceValue = response.resistanceValue;
-                        this.isUnskilled = response.isUnskilled;
-                        this._handleRolls(
-                            currentHeroPoints,
-                            maxHpToSpend,
-                            response.hpSpentAV,
-                            response.hpSpentEV,
-                            response.hpSpentOV,
-                            response.hpSpentRV,
-                            response.combatManeuver,
-                            response.resultColumnShifts,
-                            response.isUnskilled
+            buttons: [
+                {
+                    action: 'submit',
+                    label: game.i18n.localize('MEGS.Submit'),
+                    default: true,
+                    callback: (event, button, dialog) => {
+                        return this._processOpposingValuesEntry(
+                            dialog.querySelector('form')
                         );
                     },
                 },
-            },
-            default: 'button1',
-        }, {
-            classes: ['megs', 'dialog']
-        }).render(true);
+                {
+                    action: 'close',
+                    label: game.i18n.localize('MEGS.Close'),
+                },
+            ],
+            rejectClose: false,
+        });
+        if (response) {
+            this.actionValue = response.actionValue;
+            this.effectValue = response.effectValue;
+            this.opposingValue = response.opposingValue;
+            this.resistanceValue = response.resistanceValue;
+            this.isUnskilled = response.isUnskilled;
+            await this._handleRolls(
+                currentHeroPoints,
+                maxHpToSpend,
+                response.hpSpentAV,
+                response.hpSpentEV,
+                response.hpSpentOV,
+                response.hpSpentRV,
+                response.combatManeuver,
+                response.resultColumnShifts,
+                response.isUnskilled
+            );
+        }
     }
 
     /**
@@ -588,14 +594,11 @@ export class MegsTableRolls {
                     await game.dice3d.showForRoll(currentRoll, game.user, true);
                 }
 
-                const confirmed = await Dialog.confirm({
-                    title: game.i18n.localize('MEGS.ContinueRolling'),
+                const confirmed = await foundry.applications.api.DialogV2.confirm({
+                    window: { title: game.i18n.localize('MEGS.ContinueRolling') },
                     content: game.i18n.localize('MEGS.RolledDoublesPrompt'),
-                    yes: () => true,
-                    no: () => false,
-                    options: {
-                        classes: ['megs', 'dialog']
-                    }
+                    classes: ['megs', 'dialog'],
+                    rejectClose: false,
                 });
                 if (confirmed) {
                     currentRoll = new Roll(this.rollFormula, {});

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -123,7 +123,7 @@ export class MegsTableRolls {
                         default: true,
                         callback: (event, button, dialog) => {
                             return this._processOpposingValuesEntry(
-                                dialog.querySelector('form')
+                                button.form
                             );
                         },
                     },
@@ -193,7 +193,7 @@ export class MegsTableRolls {
                     default: true,
                     callback: (event, button, dialog) => {
                         return this._processOpposingValuesEntry(
-                            dialog.querySelector('form')
+                            button.form
                         );
                     },
                 },

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -17,21 +17,22 @@ export class MEGSActor extends Actor {
     async _getSkills() {
         const skillsJson = await _loadData('systems/megs/assets/data/skills.json');
 
-        const skills = [];
-        const subskills = [];
+        const allItems = [];
+        const skillIdByName = {};
         for (const i of skillsJson) {
             i.img = i.img
                 ? 'systems/megs/assets/images/icons/skillls/' + i.img
                 : 'systems/megs/assets/images/icons/skillls/skill.png';
             const item = { ...new MEGSItem(i) };
             delete item.system.subskills;
-            delete item._id;
             delete item.effects;
-            skills.push(item);
+            item._id = foundry.utils.randomID();
+            skillIdByName[i.name] = item._id;
+            allItems.push(item);
 
             if (i.system.subskills) {
                 for (const j of i.system.subskills) {
-                    const subskillObj = {
+                    allItems.push({
                         name: j.name,
                         type: 'subskill',
                         img: j.img
@@ -42,29 +43,18 @@ export class MEGSActor extends Actor {
                             totalCost: 0,
                             factorCost: 0,
                             aps: 0,
-                            parent: '',
+                            parent: skillIdByName[i.name],
                             type: j.type,
                             linkedSkill: i.name,
                             useUnskilled: j.useUnskilled,
                             isTrained: true,
                         },
-                    };
-                    subskills.push(subskillObj);
+                    });
                 }
             }
         }
 
-        this.updateSource({ items: skills });
-
-        const actorSkills = {};
-        this.items.forEach((skill) => {
-            actorSkills[skill.name] = skill._id;
-        });
-
-        for (const i of subskills) {
-            i.system.parent = actorSkills[i.system.linkedSkill];
-        }
-        this.updateSource({ items: subskills });
+        this.updateSource({ items: allItems });
     }
 
     /** @override */
@@ -86,8 +76,7 @@ export class MEGSActor extends Actor {
 
     /** @override */
     prepareBaseData() {
-        // Data modifications in this step occur before processing embedded
-        // documents or derived data.
+        super.prepareBaseData();
 
         // Ensure attributes exist and have valid values (for actors created before template updates)
         if (!this.system.attributes) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1375,28 +1375,29 @@ export class MEGSItem extends Item {
             { options }
         );
 
-        return new Promise((resolve) => {
-            new Dialog({
-                title: `${this.name} — ${game.i18n.localize('MEGS.GadgetRoll')}`,
-                content: dialogHtml,
-                buttons: {
-                    cancel: {
-                        label: game.i18n.localize('MEGS.Close'),
-                        callback: () => resolve(null),
-                    },
-                    roll: {
-                        label: game.i18n.localize('MEGS.Roll'),
-                        callback: (html) => {
-                            const idx = Number.parseInt(
-                                html[0].querySelector('input[name="selectedOption"]:checked')?.value ?? '0'
-                            );
-                            resolve(rollOptions[idx]);
-                        },
+        return foundry.applications.api.DialogV2.wait({
+            window: { title: `${this.name} — ${game.i18n.localize('MEGS.GadgetRoll')}` },
+            classes: ['megs', 'dialog'],
+            content: dialogHtml,
+            buttons: [
+                {
+                    action: 'roll',
+                    label: game.i18n.localize('MEGS.Roll'),
+                    default: true,
+                    callback: (event, button, dialog) => {
+                        const idx = Number.parseInt(
+                            dialog.querySelector('input[name="selectedOption"]:checked')?.value ?? '0'
+                        );
+                        return rollOptions[idx];
                     },
                 },
-                default: 'roll',
-                close: () => resolve(null),
-            }, { classes: ['megs', 'dialog'] }).render(true);
+                {
+                    action: 'cancel',
+                    label: game.i18n.localize('MEGS.Close'),
+                    callback: () => null,
+                },
+            ],
+            rejectClose: false,
         });
     }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1386,7 +1386,7 @@ export class MEGSItem extends Item {
                     default: true,
                     callback: (event, button, dialog) => {
                         const idx = Number.parseInt(
-                            dialog.querySelector('input[name="selectedOption"]:checked')?.value ?? '0'
+                            button.form.querySelector('input[name="selectedOption"]:checked')?.value ?? '0'
                         );
                         return rollOptions[idx];
                     },

--- a/module/helpers/effects.mjs
+++ b/module/helpers/effects.mjs
@@ -15,7 +15,7 @@ export async function onManageActiveEffect(event, owner) {
                 name: game.i18n.format('MEGS.New', {
                     type: game.i18n.localize('MEGS.ActiveEffect'),
                 }),
-                icon: 'icons/svg/aura.svg',
+                img: 'icons/svg/aura.svg',
                 origin: owner.uuid,
                 'duration.rounds': li.dataset.effectType === 'temporary' ? 1 : undefined,
                 disabled: li.dataset.effectType === 'inactive',
@@ -24,13 +24,12 @@ export async function onManageActiveEffect(event, owner) {
     case 'edit':
         return effect.sheet.render(true);
     case 'delete': {
-        const confirmed = await Dialog.confirm({
-            title: `Delete Active Effect: ${effect.name}`,
+        const confirmed = await foundry.applications.api.DialogV2.confirm({
+            window: { title: `Delete Active Effect: ${effect.name}` },
             content: '<p style="font-family: Helvetica, Arial, sans-serif;"><strong>Are You Sure?</strong> This item will be permanently deleted and cannot be recovered.</p>',
-            defaultYes: false,
-            options: {
-                classes: ['megs', 'dialog']
-            }
+            classes: ['megs', 'dialog'],
+            rejectClose: false,
+            no: { default: true },
         });
         if (confirmed) {
             return effect.delete();

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -153,11 +153,6 @@ Hooks.once('init', function () {
             console.error('[MEGS] Error loading wealth:', error);
         });
 
-    // Active Effects are never copied to the Actor,
-    // but will still apply to the Actor from within the Item
-    // if the transfer property on the Active Effect is true.
-    CONFIG.ActiveEffect.legacyTransferral = false;
-
     CONFIG.reliabilityScores = [0, 2, 3, 5, 7, 9, 11];
 
     // Register sheet application classes

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1195,7 +1195,7 @@ export class MEGSActorSheet extends ActorSheet {
                     default: true,
                     callback: (event, button, dialog) => {
                         const idx = Number.parseInt(
-                            dialog.querySelector('input[name="selectedOption"]:checked')?.value ?? '0'
+                            button.form.querySelector('input[name="selectedOption"]:checked')?.value ?? '0'
                         );
                         return rollOptions[idx];
                     },

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1371,7 +1371,7 @@ export class MEGSActorSheet extends ActorSheet {
 
     _changeEditHeaderLink(sheetHeaderLinks) {
         const found = sheetHeaderLinks.find((element) => element.label === 'Sheet');
-        found.icon = 'fas fa-file';
+        if (found) found.icon = 'fas fa-file';
     }
 
     /** @override **/

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -653,7 +653,7 @@ export class MEGSActorSheet extends ActorSheet {
         // Get the type of item to create.
         const type = header.dataset.type;
         // Grab any data associated with this control.
-        const data = duplicate(header.dataset);
+        const data = foundry.utils.deepClone(header.dataset);
         // Initialize a default name.
         const name = `New ${type.capitalize()}`;
         // Prepare the item object.
@@ -743,13 +743,12 @@ export class MEGSActorSheet extends ActorSheet {
         if (!item) return;
 
         const type = item.type.charAt(0).toUpperCase() + item.type.slice(1);
-        const confirmed = await Dialog.confirm({
-            title: `Delete ${type}: ${item.name}`,
+        const confirmed = await foundry.applications.api.DialogV2.confirm({
+            window: { title: `Delete ${type}: ${item.name}` },
             content: '<p style="font-family: Helvetica, Arial, sans-serif;"><strong>Are You Sure?</strong> This item will be permanently deleted and cannot be recovered.</p>',
-            defaultYes: false,
-            options: {
-                classes: ['megs', 'dialog']
-            }
+            classes: ['megs', 'dialog'],
+            rejectClose: false,
+            no: { default: true },
         });
 
         if (!confirmed) return;
@@ -1185,28 +1184,29 @@ export class MEGSActorSheet extends ActorSheet {
             { options }
         );
 
-        return new Promise((resolve) => {
-            new Dialog({
-                title: `${gadget.name} — ${game.i18n.localize('MEGS.GadgetRoll')}`,
-                content: dialogHtml,
-                buttons: {
-                    cancel: {
-                        label: game.i18n.localize('MEGS.Close'),
-                        callback: () => resolve(null),
-                    },
-                    roll: {
-                        label: game.i18n.localize('MEGS.Roll'),
-                        callback: (html) => {
-                            const idx = Number.parseInt(
-                                html[0].querySelector('input[name="selectedOption"]:checked')?.value ?? '0'
-                            );
-                            resolve(rollOptions[idx]);
-                        },
+        return foundry.applications.api.DialogV2.wait({
+            window: { title: `${gadget.name} — ${game.i18n.localize('MEGS.GadgetRoll')}` },
+            classes: ['megs', 'dialog'],
+            content: dialogHtml,
+            buttons: [
+                {
+                    action: 'roll',
+                    label: game.i18n.localize('MEGS.Roll'),
+                    default: true,
+                    callback: (event, button, dialog) => {
+                        const idx = Number.parseInt(
+                            dialog.querySelector('input[name="selectedOption"]:checked')?.value ?? '0'
+                        );
+                        return rollOptions[idx];
                     },
                 },
-                default: 'roll',
-                close: () => resolve(null),
-            }, { classes: ['megs', 'dialog'] }).render(true);
+                {
+                    action: 'cancel',
+                    label: game.i18n.localize('MEGS.Close'),
+                    callback: () => null,
+                },
+            ],
+            rejectClose: false,
         });
     }
 

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -339,7 +339,7 @@ export class MEGSItemSheet extends ItemSheet {
                 // Check if this is a virtual power
                 if (itemId.startsWith('virtual-power-')) {
                     const powerName = itemId.replace('virtual-power-', '');
-                    const powerAPs = foundry.utils.duplicate(this.object.system.powerAPs || {});
+                    const powerAPs = foundry.utils.deepClone(this.object.system.powerAPs || {});
 
                     if (Object.hasOwn(powerAPs, powerName)) {
                         powerAPs[powerName] = (powerAPs[powerName] || 0) + 1;
@@ -348,8 +348,8 @@ export class MEGSItemSheet extends ItemSheet {
                     }
                 } else {
                     // Update virtual skill in skillData or subskillData
-                    const skillData = foundry.utils.duplicate(this.object.system.skillData || {});
-                    const subskillData = foundry.utils.duplicate(this.object.system.subskillData || {});
+                    const skillData = foundry.utils.deepClone(this.object.system.skillData || {});
+                    const subskillData = foundry.utils.deepClone(this.object.system.subskillData || {});
 
                     if (Object.hasOwn(skillData, skillName)) {
                         skillData[skillName] = (skillData[skillName] || 0) + 1;
@@ -382,7 +382,7 @@ export class MEGSItemSheet extends ItemSheet {
                 // Check if this is a virtual power
                 if (itemId.startsWith('virtual-power-')) {
                     const powerName = itemId.replace('virtual-power-', '');
-                    const powerAPs = foundry.utils.duplicate(this.object.system.powerAPs || {});
+                    const powerAPs = foundry.utils.deepClone(this.object.system.powerAPs || {});
 
                     if (Object.hasOwn(powerAPs, powerName) && (powerAPs[powerName] || 0) > 0) {
                         powerAPs[powerName] = (powerAPs[powerName] || 0) - 1;
@@ -391,8 +391,8 @@ export class MEGSItemSheet extends ItemSheet {
                     }
                 } else {
                     // Update virtual skill in skillData or subskillData
-                    const skillData = foundry.utils.duplicate(this.object.system.skillData || {});
-                    const subskillData = foundry.utils.duplicate(this.object.system.subskillData || {});
+                    const skillData = foundry.utils.deepClone(this.object.system.skillData || {});
+                    const subskillData = foundry.utils.deepClone(this.object.system.subskillData || {});
 
                     if (Object.hasOwn(skillData, skillName) && (skillData[skillName] || 0) > 0) {
                         skillData[skillName] = (skillData[skillName] || 0) - 1;
@@ -482,13 +482,12 @@ export class MEGSItemSheet extends ItemSheet {
             }
 
             const typeDisplay = typeof itemType === 'string' ? itemType.charAt(0).toUpperCase() + itemType.slice(1) : 'Item';
-            const confirmed = await Dialog.confirm({
-                title: `Delete ${typeDisplay}: ${itemName}`,
+            const confirmed = await foundry.applications.api.DialogV2.confirm({
+                window: { title: `Delete ${typeDisplay}: ${itemName}` },
                 content: '<p style="font-family: Helvetica, Arial, sans-serif;"><strong>Are You Sure?</strong> This item will be permanently deleted and cannot be recovered.</p>',
-                defaultYes: false,
-                options: {
-                    classes: ['megs', 'dialog']
-                }
+                classes: ['megs', 'dialog'],
+                rejectClose: false,
+                no: { default: true },
             });
 
             if (!confirmed) return;
@@ -497,7 +496,7 @@ export class MEGSItemSheet extends ItemSheet {
                 // Standalone power/skill - delete virtual modifier from flattened array
                 const index = Number.parseInt(itemId.split('-')[2]);
                 const arrayKey = isVirtualBonus ? 'bonuses' : 'limitations';
-                const modifiers = foundry.utils.duplicate(this.object.system[arrayKey] || []);
+                const modifiers = foundry.utils.deepClone(this.object.system[arrayKey] || []);
 
                 // Remove the modifier at the index
                 modifiers.splice(index, 1);
@@ -1128,7 +1127,7 @@ export class MEGSItemSheet extends ItemSheet {
         // Get the type of item to create.
         const type = header.dataset.type;
         // Grab any data associated with this control.
-        const data = duplicate(header.dataset);
+        const data = foundry.utils.deepClone(header.dataset);
         // Initialize a default name.
         const name = `New ${type.capitalize()}`;
         // Prepare the item object.
@@ -1167,7 +1166,7 @@ export class MEGSItemSheet extends ItemSheet {
      * @private
      */
     async _onCreateTraitOnStandaloneGadget(itemData) {
-        const traitData = foundry.utils.duplicate(this.object.system.traitData || {});
+        const traitData = foundry.utils.deepClone(this.object.system.traitData || {});
 
         // Create a unique key using timestamp to avoid collisions
         const key = `${itemData.name}-${itemData.type}-${Date.now()}`;
@@ -1339,7 +1338,7 @@ export class MEGSItemSheet extends ItemSheet {
      * @private
      */
     async _onDropTraitToStandaloneGadget(itemData) {
-        const traitData = foundry.utils.duplicate(this.object.system.traitData || {});
+        const traitData = foundry.utils.deepClone(this.object.system.traitData || {});
 
         // Store the complete item data using a unique key (name + type + timestamp)
         const key = `${itemData.name}-${itemData.type}-${Date.now()}`;
@@ -1364,12 +1363,12 @@ export class MEGSItemSheet extends ItemSheet {
      */
     async _onDropPowerToStandaloneGadget(itemData) {
         // Duplicate all flattened power fields
-        const powerAPs = foundry.utils.duplicate(this.object.system.powerAPs || {});
-        const powerBaseCosts = foundry.utils.duplicate(this.object.system.powerBaseCosts || {});
-        const powerFactorCosts = foundry.utils.duplicate(this.object.system.powerFactorCosts || {});
-        const powerRanges = foundry.utils.duplicate(this.object.system.powerRanges || {});
-        const powerIsLinked = foundry.utils.duplicate(this.object.system.powerIsLinked || {});
-        const powerLinks = foundry.utils.duplicate(this.object.system.powerLinks || {});
+        const powerAPs = foundry.utils.deepClone(this.object.system.powerAPs || {});
+        const powerBaseCosts = foundry.utils.deepClone(this.object.system.powerBaseCosts || {});
+        const powerFactorCosts = foundry.utils.deepClone(this.object.system.powerFactorCosts || {});
+        const powerRanges = foundry.utils.deepClone(this.object.system.powerRanges || {});
+        const powerIsLinked = foundry.utils.deepClone(this.object.system.powerIsLinked || {});
+        const powerLinks = foundry.utils.deepClone(this.object.system.powerLinks || {});
 
         // Use power name as key
         const powerName = itemData.name;
@@ -1410,7 +1409,7 @@ export class MEGSItemSheet extends ItemSheet {
         const arrayKey = isBonus ? 'bonuses' : 'limitations';
 
         // Get existing array
-        const modifiers = foundry.utils.duplicate(this.object.system[arrayKey] || []);
+        const modifiers = foundry.utils.deepClone(this.object.system[arrayKey] || []);
 
         // Add new modifier data
         modifiers.push({

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig({
         screenshot: 'only-on-failure',
         actionTimeout: 10_000,
         navigationTimeout: 15_000,
+        viewport: { width: 1920, height: 1080 },
     },
     globalSetup: './e2e/fixtures/global-setup.mjs',
     projects: [

--- a/src/scss/components/_dialogs.scss
+++ b/src/scss/components/_dialogs.scss
@@ -19,7 +19,8 @@
         font-family: $font-primary;
     }
 
-    .dialog-buttons {
+    .dialog-buttons,
+    .form-footer {
         position: sticky;
         bottom: 0;
         background-color: $c-lightblue;
@@ -150,6 +151,8 @@
         padding: 8px 4px;
         font-size: 14px;
         outline: none;
+        background-color: $c-white;
+        color: $c-darkblue;
 
         // Hide the number input spin buttons
         &::-webkit-inner-spin-button,

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/230-upgrade-to-foundry-v14/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/230-upgrade-to-foundry-v14/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/230-upgrade-to-foundry-v14",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,

--- a/system.json
+++ b/system.json
@@ -22,8 +22,8 @@
     ],
     "version": "1.0.0",
     "compatibility": {
-        "minimum": 11,
-        "verified": "13.346"
+        "minimum": 14,
+        "verified": "14"
     },
     "esmodules": [
         "module/megs.mjs"

--- a/templates/item/parts/item-effects.hbs
+++ b/templates/item/parts/item-effects.hbs
@@ -23,7 +23,7 @@
                     data-parent-id="{{effect.parent.id}}">
                     <div class="item-name effect-name flexrow">
                         <img class="item-image"
-                            src="{{effect.icon}}" />
+                            src="{{effect.img}}" />
                         <h4>{{effect.name}}</h4>
                     </div>
                     <div class="effect-source">{{effect.sourceName}}</div>


### PR DESCRIPTION
## Summary
- Update `system.json` compatibility: minimum 14, verified 14
- Remove `CONFIG.ActiveEffect.legacyTransferral` (config option removed in v14)
- Replace bare global `duplicate()` and `foundry.utils.duplicate()` with `foundry.utils.deepClone()`
- Replace `foundry.utils.mergeObject()` with spread operator in combat.js
- Migrate all `Dialog` / `Dialog.confirm()` usages (9 total) to `foundry.applications.api.DialogV2`
- Change `ActiveEffect.icon` to `ActiveEffect.img` in effects.mjs and item-effects.hbs
- Add `super.prepareBaseData()` call — v14 requires it for `_clearData()` to reset ActiveEffect phases
- Combine `_getSkills()` into single `updateSource()` — v14 phased ActiveEffect application crashes on duplicate data-prep cycles
- Guard `_changeEditHeaderLink` null check — v14 removed the "Sheet" header button
- Use `button.form` instead of `dialog.querySelector('form')` in DialogV2 callbacks
- Fix DialogV2 CSS: explicit input colors, `.form-footer` button styling
- Update foundry mock to v14 API (remove v13 globals, add `foundry.utils.deepClone`, `foundry.applications.api.DialogV2`)
- Update E2E fixtures/helpers for DialogV2: `requestSubmit`, `dialog[open]` selectors, `<dialog>` element cleanup between tests
- Set Playwright viewport to 1920x1080 (v14 minimum 1366x768)

## Test plan
- [x] All 128 Jest unit tests pass
- [x] ESLint passes on all changed files (no new lint errors)
- [x] E2E Playwright suite against v14: 154 passed, 5 flaky (pass on retry), 0 failed
- [x] Manual verification in Foundry VTT v14: hero sheet (Aquaman), villain sheet (Catwoman), roll dialog (DEX roll with chat output), compendium packs (all 6 loaded with correct counts), system settings (4 registered)

Fixes #230