### PR TITLE
Hide Pet actor type from create menu

### DIFF
--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -184,6 +184,12 @@ Hooks.once('init', function () {
     registerSystemSettings();
 });
 
+Hooks.once('setup', function () {
+    const types = game.documentTypes.Actor;
+    const idx = types.indexOf('pet');
+    if (idx !== -1) types.splice(idx, 1);
+});
+
 /* -------------------------------------------- */
 /*  Handlebars Helpers                          */
 /* -------------------------------------------- */

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -185,9 +185,8 @@ Hooks.once('init', function () {
 });
 
 Hooks.once('setup', function () {
-    const types = game.documentTypes.Actor;
-    const idx = types.indexOf('pet');
-    if (idx !== -1) types.splice(idx, 1);
+    delete game.model.Actor.pet;
+    delete CONFIG.Actor.typeLabels.pet;
 });
 
 /* -------------------------------------------- */

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.0-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/hide-pet-actor-type/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.0-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.1.0-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/hide-pet-actor-type/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/hide-pet-actor-type",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
## Summary
- Removes `pet` from `game.documentTypes.Actor` in a `setup` hook so it no longer appears in the Create Actor type dropdown
- Existing pet actors are unaffected — only the create menu is changed
- Partial fix for #248; when the pet sheet template is implemented, remove the `setup` hook to re-expose the type

## Test plan
- [ ] Open Foundry, click Create Actor — "Pet" should not appear in the type dropdown
- [ ] Any existing pet actors still load without errors (data is preserved)