### PR TITLE
Allow Foundry publish workflow to be triggered manually

### DIFF
--- a/.github/workflows/foundry-release.yml
+++ b/.github/workflows/foundry-release.yml
@@ -3,6 +3,12 @@ name: Publish to Foundry
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v1.0.0)"
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -12,4 +18,4 @@ jobs:
         uses: cs96and/FoundryVTT-release-package@v1
         with:
           package-token: ${{ secrets.FOUNDRY_PACKAGE_TOKEN }}
-          manifest-url: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/system.json
+          manifest-url: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name || inputs.tag }}/system.json

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/ci/foundry-publish-workflow-dispatch/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/ci/foundry-publish-workflow-dispatch/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/ci/foundry-publish-workflow-dispatch",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger with a `tag` input to `foundry-release.yml`, so a failed release publish can be retried at any time.

GitHub refuses to re-run workflow runs older than 30 days. The 1.0.0 Foundry publish failed on 2026-01-19 and is now unrecoverable by re-run, leaving the Foundry registry stuck on 0.7.0 with no way to retry short of re-publishing the release (which would reset its release date).

The manifest URL falls back to the dispatch input when there is no release event payload:

```
${{ github.event.release.tag_name || inputs.tag }}
```

Existing `release: published` behaviour is unchanged.

Targets `main` rather than a release branch because `workflow_dispatch` only appears in the Actions UI when the workflow exists on the default branch.