### PR TITLE
Sync system.json URLs on main and fix version string

### DIFF
--- a/.github/workflows/sync-system-json-urls.yml
+++ b/.github/workflows/sync-system-json-urls.yml
@@ -2,7 +2,6 @@ name: Sync system.json URLs
 
 on:
   push:
-    branches-ignore: [main]
 
 permissions:
   contents: write

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "browserslist": [
         "last 3 versions"
     ],
-    "description": "Unofficial Multversal Exponential Game System (MEGS) RPG Support for Foundry VTT",
+    "description": "Unofficial Multiversal Exponential Game System (MEGS) RPG Support for Foundry VTT",
     "devDependencies": {
         "@babel/preset-env": "^7.23.2",
         "@playwright/test": "^1.61.1",

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/main/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/fix/system-json-url-sync-on-main/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/main/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/main",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/fix/system-json-url-sync-on-main/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/fix/system-json-url-sync-on-main",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,

--- a/system.json
+++ b/system.json
@@ -16,11 +16,11 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/ci/foundry-publish-workflow-dispatch/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/main/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
-    "version": "1.0.1.",
+    "version": "1.0.1",
     "compatibility": {
         "minimum": 11,
         "verified": "13.346"
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/ci/foundry-publish-workflow-dispatch/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/ci/foundry-publish-workflow-dispatch",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/main/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/main",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
`sync-system-json-urls.yml` ran with `branches-ignore: [main]`, so `main` was never corrected. It kept whatever branch-specific URLs arrived with the last merge.

`main` currently points at `ci/foundry-publish-workflow-dispatch`; before that it pointed at `MEGS-1.0.1-Release`. Each URL breaks once its branch is deleted. Every merge reintroduces the problem.

Removing the branch filter makes the workflow run on `main` too, where `GITHUB_REF_NAME` is `main`, so the URLs reset after every merge. No loop risk: pushes made with `GITHUB_TOKEN` do not trigger further workflow runs, and the job already exits early when `system.json` is unchanged.

Also fixes `version`, which was `"1.0.1."` with a trailing period since f7850b9.

Note: pushing this branch triggers the existing workflow, so the bot will rewrite the URLs in this PR to the branch name. After merge, the new main run resets them to `main`.