### PR TITLE
Set system.json version to 1.0.1 on the 1.0.1 release branch

### DIFF
--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/fix/1.0.1-version-string/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.0.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.0.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/fix/1.0.1-version-string/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/fix/1.0.1-version-string",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,

--- a/system.json
+++ b/system.json
@@ -20,7 +20,7 @@
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
-    "version": "1.0.0",
+    "version": "1.0.1",
     "compatibility": {
         "minimum": 11,
         "verified": "13.346"


### PR DESCRIPTION
`MEGS-1.0.1-Release` still declared `"version": "1.0.0"`, so anything tagged from this branch would ship a 1.0.0 manifest under a 1.0.1 tag.

Note this branch is already fully merged into `main`, and `main` carries the version fix separately in #265, so tagging 1.0.1 would most likely come off `main`. This keeps the release branch self-consistent either way.