### PR TITLE
Restrict system.json URL sync to branches, not tags

### DIFF
--- a/.github/workflows/sync-system-json-urls.yml
+++ b/.github/workflows/sync-system-json-urls.yml
@@ -2,6 +2,7 @@ name: Sync system.json URLs
 
 on:
   push:
+    branches: ['**']
 
 permissions:
   contents: write

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/main/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/fix/url-sync-skip-tags/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/main/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/main",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/fix/url-sync-skip-tags/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/fix/url-sync-skip-tags",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
Dropping `branches-ignore: [main]` in #265 left `on: push:` unfiltered, which matches tags as well as branches.

Pushing `v1.0.1` ran the workflow with `GITHUB_REF_NAME=v1.0.1` on a detached HEAD. It rewrote `system.json` to point at a "v1.0.1" branch that does not exist, committed, then failed on `git push` with `fatal: You are not currently on a branch` (run 30512367255).

Nothing landed, since the push failed — `main` and the `v1.0.1` tag both still carry the correct `main` URLs, and the published release assets were built before the run. But every future tag push would repeat the failure.

`branches: ['**']` matches all branches including `main`, and excludes tags.