### PR TITLE
Bump version to 1.1.0 and set verified compatibility to 14.365

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It's a mouthful, is what it is. Let's go with "MEGS for Foundry."
 
 This is a fan-created implementation of the Mayfair Exponential Gaming System, whose core mechanics were used in games such as DC Heroes, Underground, and Blood of Heroes. The core mechanics of the DC Heroes / Underground / Blood of Heroes games were dubbed "MEGS" by its fans, short for ["Mayfair Eponential Gaming System."](https://en.wikipedia.org/wiki/Mayfair_Exponential_Game_System) This was an informal name, never trademarked.
 
-The current version (1.0.1) of MEGS for Foundry has basic character sheets, some die rolling, outcome resolution, and a generic skill tree. It allows you to create heroes, villains, NPCs, powers, gadgets, character traits, power modifications, etc. It's very much a skeleton for running games featuring any superheroes (or villains; I don't discriminate) you want using MEGS at a level similar to DC Heroes 3rd Edition or Blood of Heroes - if you enter your own Powers, Advantages, Drawbacks, Bonuses, Limitations, etc.
+The current version (1.1.0) of MEGS for Foundry has basic character sheets, some die rolling, outcome resolution, and a generic skill tree. It allows you to create heroes, villains, NPCs, powers, gadgets, character traits, power modifications, etc. It's very much a skeleton for running games featuring any superheroes (or villains; I don't discriminate) you want using MEGS at a level similar to DC Heroes 3rd Edition or Blood of Heroes - if you enter your own Powers, Advantages, Drawbacks, Bonuses, Limitations, etc.
 
 It's also a work in progress. I basically tackled it on a whim to teach myself to code the Foundry framework. I will try very hard to make any changes backward compatible so that you can use any characters or items you create after later versions, but... not promising anything until we get to version 1.0.0.
 
@@ -48,7 +48,7 @@ To use compendium items:
 
 ### Do you have future plans?
 
-Do I ever! MEGS for Foundry is currently sitting at **version 1.0.1**.
+Do I ever! MEGS for Foundry is currently sitting at **version 1.1.0**.
 
 (Note that everything below is subject to change.)
 

--- a/system.json
+++ b/system.json
@@ -16,14 +16,14 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.0-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/bump-version-1.1.0/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
-    "version": "1.0.1",
+    "version": "1.1.0",
     "compatibility": {
         "minimum": 14,
-        "verified": "14"
+        "verified": "14.365"
     },
     "esmodules": [
         "module/megs.mjs"
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.0-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.1.0-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/bump-version-1.1.0/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/bump-version-1.1.0",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
Prepares the 1.1.0 release.

- `system.json` `version`: `1.0.1` -> `1.1.0`
- `system.json` `compatibility.verified`: `"14"` -> `"14.365"` — was a bare major; the release has been tested against build 14.365
- README version references updated to match

`compatibility.minimum` stays at 14.

The manifest/download URLs in the diff were rewritten by the post-checkout hook to point at this branch; the sync-system-json-urls action repoints them at the release branch on merge.