### PR TITLE
Set minimum compatibility to 14.359 and point manifest URLs at main

### DIFF
--- a/system.json
+++ b/system.json
@@ -16,13 +16,13 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.0-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/main/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
     "version": "1.1.0",
     "compatibility": {
-        "minimum": 14,
+        "minimum": "14.359",
         "verified": "14.365"
     },
     "esmodules": [
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.0-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.1.0-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/main/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/main",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/main/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/set-minimum-14.359/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/main/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/main",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/set-minimum-14.359/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/set-minimum-14.359",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
Ahead of tagging `v1.1.0`.

- `compatibility.minimum`: `14` -> `"14.359"` — the earliest supported Foundry build
- `media[0].url`, `manifest`, `download`: were pointing at `MEGS-1.1.0-Release`, inherited from the release merge

The `sync-system-json-urls` workflow has `branches-ignore: [main]`, so nothing corrects those URLs on `main`; left alone they would dangle once the release branch is deleted. Pointing them at `main` matches the manifest published with v1.0.1.

`verified` stays at `14.365`; `version` stays at `1.1.0`.