### PR TITLE
Fix roll dialog controls broken by Foundry v14 HTML sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CHANGELOG
 
+## 1.1.1
+
+### Bug Fixes
+
+- Fixed roll dialog controls broken by Foundry v14 (issue #275). v14 runs DialogV2 string content through `foundry.utils.cleanHTML()`, which strips inline `on*` handlers, so:
+    - The `-`/`+` buttons beside Action, Effect, Opposing and Resistance Value had become plain submit buttons — clicking one closed the dialog and discarded the roll instead of changing the value
+    - The number beside each Hero Point slider never moved off 0, even though the hero points were being applied to the roll
+    - The initiative dialog's Hero Point slider readout was dead for the same reason
+- Increment/decrement buttons now respect the field's own minimum and maximum instead of stepping past them
+
+### Enhancements
+
+- Roll dialog now shows how many Hero Points the character has, and says so explicitly when there are none to spend
+
+### Test Infrastructure
+
+- Added E2E coverage that clicks the roll dialog's `+`/`-` buttons and drags its sliders through real pointer input; the previous specs set `.value` directly, which could not see this class of failure
+- Added unit tests for increment/decrement bounds handling
+
 ## 1.1.0
 
 ### Foundry VTT v14 Compatibility

--- a/css/megs.css
+++ b/css/megs.css
@@ -1542,6 +1542,14 @@ details summary.no-arrow {
   background: #5fa2d9;
   margin-bottom: 10px;
 }
+.megs-dialog .hero-points-available {
+  margin: 0 0 10px 0;
+  font-size: 13px;
+}
+.megs-dialog .hero-points-available .hint {
+  font-style: italic;
+  opacity: 0.75;
+}
 .megs-dialog .flexrow {
   display: flex;
   align-items: center;
@@ -1788,5 +1796,3 @@ li.chat-message .tooltip .tooltiptext .init-table .value {
   font-weight: bold;
   white-space: nowrap;
 }
-
-/*# sourceMappingURL=megs.css.map */

--- a/e2e/tests/roll-dialog-controls.spec.mjs
+++ b/e2e/tests/roll-dialog-controls.spec.mjs
@@ -1,0 +1,188 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    deleteActor,
+    openActorSheet,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+import {
+    waitForRollDialog,
+    closeRollDialog,
+    getChatMessageCount,
+} from '../fixtures/roll-helpers.mjs';
+
+/**
+ * Issue #275: Foundry v14 runs DialogV2 string content through
+ * foundry.utils.cleanHTML(), which strips every inline on* attribute. The roll
+ * dialog's controls used to rely on them, so its +/- buttons became bare submit
+ * buttons that closed the dialog and discarded the roll, and its hero-point
+ * slider readouts never moved.
+ *
+ * These tests drive the controls the way a player does -- real clicks and a real
+ * pointer drag -- because the defect was invisible to any test that set .value
+ * directly, which is what every other spec here does.
+ */
+test.describe('Roll dialog controls (#275)', () => {
+    async function setHeroPoints(page, actorId, value) {
+        await page.evaluate(async ({ id, value }) => {
+            await game.actors.get(id).update({ 'system.heroPoints.value': value });
+        }, { id: actorId, value });
+    }
+
+    async function openDexRollDialog(page, actorId) {
+        await page.evaluate(() => {
+            for (const t of [...game.user.targets]) {
+                t.setTarget(false, { user: game.user, releaseOthers: false });
+            }
+        });
+        await openActorSheet(page, actorId, 'abilities');
+        await page.click('.sheet.actor .tab.abilities .resource-label.rollable[data-key="dex"]');
+        await waitForRollDialog(page);
+    }
+
+    /** Expand "Hero Point options" by clicking its summary, as a player would. */
+    async function openHeroPointOptions(page) {
+        await page.locator('dialog.dialog[open] .megs-dialog details').first()
+            .locator('summary').click();
+        await page.waitForFunction(
+            () => [...document.querySelectorAll('dialog.dialog[open]')]
+                .find(d => d.querySelector('#actionValue'))
+                ?.querySelector('details')?.open === true,
+            null,
+            { timeout: 5000 }
+        );
+    }
+
+    function stepper(page, fieldId, direction) {
+        return page.locator(
+            `dialog.dialog[open] .quantity[data-control="stepper"]:has(#${fieldId}) button.${direction}`
+        );
+    }
+
+    test('the + button raises the field instead of submitting the dialog', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('RDC_Plus'), { dex: 8 });
+            await openDexRollDialog(page, actorId);
+
+            const av = page.locator('dialog.dialog[open] #actionValue');
+            await expect(av).toHaveValue('8');
+
+            const chatBefore = await getChatMessageCount(page);
+            await stepper(page, 'actionValue', 'plus').click();
+            await stepper(page, 'actionValue', 'plus').click();
+
+            await expect(av).toHaveValue('10');
+            // The regression: a stripped handler left a submit button, so clicking
+            // + tore the dialog down and the roll was lost.
+            await expect(page.locator('dialog.dialog[open] #actionValue')).toBeVisible();
+            expect(await getChatMessageCount(page)).toBe(chatBefore);
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('the - button lowers the field and stops at its minimum', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('RDC_Minus'), { dex: 2 });
+            await openDexRollDialog(page, actorId);
+
+            const av = page.locator('dialog.dialog[open] #actionValue');
+            await expect(av).toHaveValue('2');
+
+            await stepper(page, 'actionValue', 'minus').click();
+            await expect(av).toHaveValue('1');
+            await stepper(page, 'actionValue', 'minus').click();
+            await expect(av).toHaveValue('0');
+            // min="0" on the input, so a further click must not go negative.
+            await stepper(page, 'actionValue', 'minus').click();
+            await expect(av).toHaveValue('0');
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('dragging a hero-point slider updates the number beside it', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('RDC_Slider'), { dex: 8 });
+            await setHeroPoints(page, actorId, 10);
+            await openDexRollDialog(page, actorId);
+            await openHeroPointOptions(page);
+
+            const slider = page.locator('dialog.dialog[open] input[name="hpSpentAV"]');
+            const readout = page.locator('dialog.dialog[open] #hpSpentAPRangeValue');
+
+            // Assert the starting state before asserting it changes, so a renamed
+            // selector fails here rather than silently matching nothing later.
+            await expect(slider).toHaveValue('0');
+            await expect(readout).toHaveText('0');
+
+            const box = await slider.boundingBox();
+            await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+            await page.mouse.down();
+            await page.mouse.move(box.x + box.width - 1, box.y + box.height / 2, { steps: 10 });
+            await page.mouse.up();
+
+            // max is min(heroPoints 10, DEX 8) = 8.
+            await expect(slider).toHaveValue('8');
+            await expect(readout).toHaveText('8');
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('with no hero points the sliders are capped at 0 and say so', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('RDC_Broke'), { dex: 8 });
+            await setHeroPoints(page, actorId, 0);
+            await openDexRollDialog(page, actorId);
+            await openHeroPointOptions(page);
+
+            const slider = page.locator('dialog.dialog[open] input[name="hpSpentAV"]');
+            await expect(slider).toHaveAttribute('max', '0');
+
+            const available = page.locator('dialog.dialog[open] .hero-points-available');
+            await expect(available).toBeVisible();
+            await expect(available).toContainText('0');
+            await expect(available.locator('.hint')).toBeVisible();
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+
+    test('the available hero point total is shown when the actor has some', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('RDC_Avail'), { dex: 8 });
+            await setHeroPoints(page, actorId, 37);
+            await openDexRollDialog(page, actorId);
+            await openHeroPointOptions(page);
+
+            const available = page.locator('dialog.dialog[open] .hero-points-available');
+            await expect(available).toContainText('37');
+            // The "nothing to spend" hint belongs only to the zero case.
+            await expect(available.locator('.hint')).toHaveCount(0);
+
+            await closeRollDialog(page);
+        } finally {
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/lang/en.json
+++ b/lang/en.json
@@ -90,6 +90,8 @@
         "HasSkills": "Has skills?",
         "HasTraits": "Has traits?",
         "HeroPointOptions": "Hero Point options",
+        "HeroPointsAvailable": "Hero Points available",
+        "NoHeroPointsToSpend": "none to spend on this roll",
         "HideZeroRankSkills": "Hide Zero Rank Skills?",
         "IsArmor": "Is armor?",
         "IsALocation": "Is a location?",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -90,6 +90,8 @@
         "HasTraits": "Possui traços?",
         "HeroPoints": "Pontos Heróicos",
         "HeroPointOptions": "Opções de pontos heróicos",
+        "HeroPointsAvailable": "Pontos Heróicos disponíveis",
+        "NoHeroPointsToSpend": "nenhum para gastar nesta rolagem",
         "HPSpent": "Gasto de PH (Pontos heroicos)",
         "HideZeroRankSkills": "Ocultar habilidades de classificação zero?",
         "InitialBonus": "Bônus inicial",

--- a/module/__tests__/dialog-controls.test.js
+++ b/module/__tests__/dialog-controls.test.js
@@ -1,0 +1,49 @@
+import { stepValue } from '../helpers/dialog-controls.mjs';
+
+/**
+ * Bounds arrive as raw HTML attribute strings, so the empty-string cases are the
+ * ones that matter: Number('') is 0, and treating that as a real bound would pin
+ * every unbounded stepper to zero.
+ */
+describe('stepValue', () => {
+    test('adds the delta when the result is within bounds', () => {
+        expect(stepValue('5', 1, '0', '10')).toBe(6);
+        expect(stepValue('5', -1, '0', '10')).toBe(4);
+    });
+
+    test('clamps to min instead of stepping below it', () => {
+        expect(stepValue('0', -1, '0', '10')).toBe(0);
+    });
+
+    test('clamps to max instead of stepping above it', () => {
+        expect(stepValue('10', 1, '0', '10')).toBe(10);
+    });
+
+    test('honors a negative min, as current condition tracks use', () => {
+        expect(stepValue('-7', -1, '-8', '')).toBe(-8);
+        expect(stepValue('-8', -1, '-8', '')).toBe(-8);
+    });
+
+    test('treats an empty max as unbounded rather than as zero', () => {
+        expect(stepValue('40', 1, '0', '')).toBe(41);
+    });
+
+    test('treats an empty min as unbounded rather than as zero', () => {
+        expect(stepValue('0', -1, '', '')).toBe(-1);
+    });
+
+    test('treats a missing min/max as unbounded', () => {
+        expect(stepValue('3', 1, undefined, undefined)).toBe(4);
+        expect(stepValue('3', -1, null, null)).toBe(2);
+    });
+
+    test('treats a blank or non-numeric current value as zero', () => {
+        expect(stepValue('', 1, '0', '10')).toBe(1);
+        expect(stepValue('abc', 1, '0', '10')).toBe(1);
+        expect(stepValue('', -1, '0', '10')).toBe(0);
+    });
+
+    test('cannot move a slider whose max equals its min', () => {
+        expect(stepValue('0', 1, '0', '0')).toBe(0);
+    });
+});

--- a/module/combat/combat.js
+++ b/module/combat/combat.js
@@ -1,4 +1,5 @@
 import { MEGS } from '../helpers/config.mjs';
+import { activateDialogControls } from '../helpers/dialog-controls.mjs';
 
 // eslint-disable-next-line no-undef
 export default class MEGSCombat extends Combat {
@@ -164,6 +165,9 @@ export default class MEGSCombat extends Combat {
             window: { title: label },
             classes: ['megs', 'dialog'],
             content: dialogHtml,
+            // DialogV2 sanitizes string content, so the slider readout has to be
+            // wired here rather than by an inline handler in the template.
+            render: (event, dialog) => activateDialogControls(dialog.element),
             buttons: [
                 {
                     action: 'roll',

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -1,3 +1,5 @@
+import { activateDialogControls } from './helpers/dialog-controls.mjs';
+
 export const ShowResultCall = Object.freeze({
     FAILURE: 0,
     ALL_RESULT: 1,
@@ -113,6 +115,7 @@ export class MegsTableRolls {
         const data = {
             valueOrAps: this.valueOrAps,
             maxHpToSpend: maxHpToSpend,
+            currentHeroPoints,
             isTargeted,
             combatManeuvers: CONFIG.combatManeuvers,
             actionValue: this.actionValue,
@@ -127,6 +130,9 @@ export class MegsTableRolls {
             window: { title },
             classes: ['megs', 'dialog'],
             content: dialogHtml,
+            // DialogV2 sanitizes string content, so the dialog's own controls have
+            // to be wired here rather than by inline handlers in the template.
+            render: (event, dialog) => activateDialogControls(dialog.element),
             buttons: [
                 {
                     action: 'submit',

--- a/module/helpers/dialog-controls.mjs
+++ b/module/helpers/dialog-controls.mjs
@@ -1,0 +1,91 @@
+/**
+ * Behaviour for markup that has to survive Foundry's HTML sanitizer.
+ *
+ * Foundry v14's DialogV2 runs string `content` through `foundry.utils.cleanHTML()`,
+ * an allow-list sanitizer that strips every inline `on*` attribute. Any markup that
+ * can appear inside a dialog therefore cannot carry its own behaviour in the
+ * template and must be wired up after render.
+ *
+ * Both helpers bind on explicit `data-` attributes rather than on class names, so
+ * they only ever attach to markup written for them. Several sheet templates still
+ * use inline handlers; those are ApplicationV1, are never sanitized, and must not
+ * also be driven from here or every click would be counted twice.
+ */
+
+/**
+ * Add `delta` to `rawValue`, clamped to the `rawMin`/`rawMax` bounds.
+ *
+ * All three inputs arrive as HTML attribute strings. An absent min/max reads as
+ * an empty string and means "unbounded", which has to be special-cased because
+ * Number('') is 0 -- treating it as a bound would pin every unbounded stepper to
+ * zero. A blank or non-numeric current value is treated as 0 so a cleared field
+ * still steps rather than going NaN.
+ *
+ * Exported separately from the DOM wiring so the arithmetic can be tested
+ * without a DOM.
+ *
+ * @param {string} rawValue   The input's current value attribute
+ * @param {number} delta      How much to add (typically 1 or -1)
+ * @param {string} rawMin     The input's min attribute, '' when unbounded
+ * @param {string} rawMax     The input's max attribute, '' when unbounded
+ * @returns {number}          The new value, within bounds
+ */
+export function stepValue(rawValue, delta, rawMin, rawMax) {
+    const min = rawMin === '' || rawMin === undefined || rawMin === null
+        ? Number.NEGATIVE_INFINITY
+        : Number(rawMin);
+    const max = rawMax === '' || rawMax === undefined || rawMax === null
+        ? Number.POSITIVE_INFINITY
+        : Number(rawMax);
+    const current = Number.parseInt(rawValue, 10);
+    const next = (Number.isNaN(current) ? 0 : current) + delta;
+    return Math.min(max, Math.max(min, next));
+}
+
+/**
+ * Wire the -/+ buttons of every `[data-control="stepper"]` group under `root`.
+ *
+ * The buttons must be type="button". Left as the default type="submit" they
+ * submit the surrounding form, which inside a DialogV2 closes the dialog and
+ * discards the roll.
+ */
+export function activateStepperControls(root) {
+    for (const group of root.querySelectorAll('[data-control="stepper"]')) {
+        const input = group.querySelector('input');
+        if (!input) continue;
+        for (const button of group.querySelectorAll('button[data-step]')) {
+            button.addEventListener('click', (event) => {
+                event.preventDefault();
+                input.value = String(
+                    stepValue(input.value, Number(button.dataset.step), input.min, input.max)
+                );
+            });
+        }
+    }
+}
+
+/**
+ * Keep each range input's readout element in step with its value.
+ *
+ * The readout is synced once on attach as well as on input: a slider whose max is
+ * 0 can never fire an input event, and its readout would otherwise be whatever
+ * the template hardcoded.
+ */
+export function activateRangeReadouts(root) {
+    for (const input of root.querySelectorAll('input[type="range"][data-readout]')) {
+        const readout = root.querySelector(`#${CSS.escape(input.dataset.readout)}`);
+        if (!readout) continue;
+        const sync = () => {
+            readout.textContent = input.value;
+        };
+        input.addEventListener('input', sync);
+        sync();
+    }
+}
+
+/** Attach every control behaviour a MEGS dialog needs. Safe on a null element. */
+export function activateDialogControls(root) {
+    if (!root) return;
+    activateStepperControls(root);
+    activateRangeReadouts(root);
+}

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -1247,15 +1247,16 @@ Handlebars.registerPartial('plusMinusInput', function (args) {
     const value = args.value && !isNaN(args.value) ? args.value : '0';
     const tabindex = args.tabindex ? 'tablindex="' + args.tabindex + '"' : '';
 
+    // No inline onClick, and type="button" rather than the default submit: this
+    // partial also renders inside DialogV2, whose content is run through
+    // foundry.utils.cleanHTML(). That strips on* attributes, leaving a bare submit
+    // button that closes the dialog instead of stepping the value. Behaviour is
+    // attached by activateStepperControls() via data-control="stepper".
     return (
         '<div class="quantity ' +
         classes +
-        '">' +
-        '<button class="minus" aria-label="Decrease" onClick="' +
-        args.id +
-        'Input.value = parseInt(' +
-        args.id +
-        'Input.value) - 1">&minus;</button>' +
+        '" data-control="stepper">' +
+        '<button type="button" class="minus" data-step="-1" aria-label="Decrease">&minus;</button>' +
         '<input id="' +
         args.id +
         'Input" name="system.' +
@@ -1270,11 +1271,7 @@ Handlebars.registerPartial('plusMinusInput', function (args) {
         '" data-dtype="Number"' +
         tabindex +
         '>' +
-        '<button class="plus" aria-label="Increase" onClick="' +
-        args.id +
-        'Input.value = parseInt(' +
-        args.id +
-        'Input.value)+ 1 ">&plus;</button>' +
+        '<button type="button" class="plus" data-step="1" aria-label="Increase">&plus;</button>' +
         '</div>'
     );
 });

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -2,6 +2,7 @@ import { MEGS } from '../helpers/config.mjs';
 import { MegsTableRolls, RollValues } from '../dice.mjs';
 import { Utils } from '../utils.js';
 import { showGadgetRollPicker } from '../helpers/gadget-picker.mjs';
+import { activateStepperControls } from '../helpers/dialog-controls.mjs';
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -561,6 +562,10 @@ export class MEGSActorSheet extends ActorSheet {
     /** @override */
     activateListeners(html) {
         super.activateListeners(html);
+
+        // The plusMinusInput partial renders both here and inside DialogV2, so it
+        // carries no inline handlers and is wired up explicitly instead.
+        activateStepperControls(html[0] ?? html);
 
         // Restore accordion state after render
         this._restoreAccordionState(html);

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -3,6 +3,7 @@ import { MEGSItem } from '../documents/item.mjs';
 import { MEGS } from '../helpers/config.mjs';
 import { MegsTableRolls, RollValues } from '../dice.mjs';
 import { Utils } from '../utils.js';
+import { activateStepperControls } from '../helpers/dialog-controls.mjs';
 
 /**
  * Extend the basic ItemSheet with some very simple modifications
@@ -253,6 +254,10 @@ export class MEGSItemSheet extends ItemSheet {
     /** @override */
     activateListeners(html) {
         super.activateListeners(html);
+
+        // The plusMinusInput partial renders both here and inside DialogV2, so it
+        // carries no inline handlers and is wired up explicitly instead.
+        activateStepperControls(html[0] ?? html);
 
         if (this._settingsTabActive) {
             html.find('.tab[data-tab="settings"]').addClass('active');

--- a/src/scss/components/_dialogs.scss
+++ b/src/scss/components/_dialogs.scss
@@ -92,6 +92,16 @@
         }
     }
 
+    .hero-points-available {
+        margin: 0 0 10px 0;
+        font-size: 13px;
+
+        .hint {
+            font-style: italic;
+            opacity: 0.75;
+        }
+    }
+
     .flexrow {
         display: flex;
         align-items: center;

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.0-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/275-roll-dialog-inline-handlers/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.0-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.1.0-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/275-roll-dialog-inline-handlers/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/275-roll-dialog-inline-handlers",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,

--- a/templates/actor/dialogs/initiativeDialog.hbs
+++ b/templates/actor/dialogs/initiativeDialog.hbs
@@ -3,7 +3,7 @@
         <div class='form-group'>
             <label>{{localize 'MEGS.HPSpent'}} - {{localize 'MEGS.Initiative'}}</label>
             <div class='flexrow'>
-                <input type='range' name='hpSpentInitiative' value='0' min='0' max='{{maxHpToSpend}}' step='1' oninput='hpSpentInitiativeValue.innerText = this.value' />
+                <input type='range' name='hpSpentInitiative' value='0' min='0' max='{{maxHpToSpend}}' step='1' data-readout='hpSpentInitiativeValue' />
                 <span class='range-value' id='hpSpentInitiativeValue'>0</span>
             </div>
         </div>

--- a/templates/dialogs/rollDialog.hbs
+++ b/templates/dialogs/rollDialog.hbs
@@ -2,64 +2,70 @@
     <form>
         <div class="form-group">
             <label>{{localize "MEGS.ActionValue"}}</label>
-            <div class="quantity">
-                <button class="minus" aria-label="Decrease" onClick="if (parseInt(actionValue.value) > 0)  actionValue.value = parseInt(actionValue.value) - 1">&minus;</button>
-                <input id="actionValue" name="actionValue" type="number" class="input-box" value="{{actionValue}}" min="0" max="">
-                <button class="plus" aria-label="Increase" onClick="actionValue.value = parseInt(actionValue.value)+ 1 ">&plus;</button>
+            <div class="quantity" data-control="stepper">
+                <button type="button" class="minus" data-step="-1" aria-label="Decrease">&minus;</button>
+                <input id="actionValue" name="actionValue" type="number" class="input-box" value="{{actionValue}}" min="0">
+                <button type="button" class="plus" data-step="1" aria-label="Increase">&plus;</button>
             </div>
         </div>
         <div class="form-group">
             <label>{{localize "MEGS.EffectValue"}}</label>
-            <div class="quantity">
-                <button class="minus" aria-label="Decrease" onClick="if (parseInt(effectValue.value) > 0)  effectValue.value = parseInt(effectValue.value) - 1">&minus;</button>
-                <input id="effectValue" name="effectValue" type="number" class="input-box" value="{{effectValue}}" min="0" max="">
-                <button class="plus" aria-label="Increase" onClick="effectValue.value = parseInt(effectValue.value)+ 1 ">&plus;</button>
+            <div class="quantity" data-control="stepper">
+                <button type="button" class="minus" data-step="-1" aria-label="Decrease">&minus;</button>
+                <input id="effectValue" name="effectValue" type="number" class="input-box" value="{{effectValue}}" min="0">
+                <button type="button" class="plus" data-step="1" aria-label="Increase">&plus;</button>
             </div>
         </div>
         <div class="form-group">
             <label>{{localize "MEGS.OpposingValue"}}</label>
-            <div class="quantity">
-                <button class="minus" aria-label="Decrease" onClick="if (parseInt(opposingValue.value) > 0)  opposingValue.value = parseInt(opposingValue.value) - 1">&minus;</button>
-                <input id="opposingValue" name="opposingValue" type="number" class="input-box" value="{{opposingValue}}" min="0" max="">
-                <button class="plus" aria-label="Increase" onClick="opposingValue.value = parseInt(opposingValue.value)+ 1 ">&plus;</button>
+            <div class="quantity" data-control="stepper">
+                <button type="button" class="minus" data-step="-1" aria-label="Decrease">&minus;</button>
+                <input id="opposingValue" name="opposingValue" type="number" class="input-box" value="{{opposingValue}}" min="0">
+                <button type="button" class="plus" data-step="1" aria-label="Increase">&plus;</button>
             </div>
         </div>
         <div class="form-group">
             <label>{{localize "MEGS.ResistanceValue"}}</label>
-            <div class="quantity">
-                <button class="minus" aria-label="Decrease" onClick="if (parseInt(resistanceValue.value) > 0) resistanceValue.value = parseInt(resistanceValue.value) - 1">&minus;</button>
-                <input id="resistanceValue" name="resistanceValue" type="number" class="input-box" value="{{resistanceValue}}" min="0" max="">
-                <button class="plus" aria-label="Increase" onClick="resistanceValue.value = parseInt(resistanceValue.value)+ 1 ">&plus;</button>
+            <div class="quantity" data-control="stepper">
+                <button type="button" class="minus" data-step="-1" aria-label="Decrease">&minus;</button>
+                <input id="resistanceValue" name="resistanceValue" type="number" class="input-box" value="{{resistanceValue}}" min="0">
+                <button type="button" class="plus" data-step="1" aria-label="Increase">&plus;</button>
             </div>
         </div>
 
         <details>
             <summary class="roll-dialog-summary">{{localize "MEGS.HeroPointOptions"}}</summary>
+            <p class="hero-points-available">
+                {{localize "MEGS.HeroPointsAvailable"}}: <strong>{{currentHeroPoints}}</strong>
+                {{#unless maxHpToSpend}}
+                    <span class="hint">({{localize "MEGS.NoHeroPointsToSpend"}})</span>
+                {{/unless}}
+            </p>
             <div class="form-group">
                 <label>{{localize "MEGS.HPSpent"}} - {{localize "MEGS.Acting"}}</label>
                 <div class="flexrow">
-                    <input type="range" name="hpSpentAV" value="0" min="0" max="{{maxHpToSpend}}" step="1" oninput="hpSpentAPRangeValue.innerText = this.value">
+                    <input type="range" name="hpSpentAV" value="0" min="0" max="{{maxHpToSpend}}" step="1" data-readout="hpSpentAPRangeValue">
                     <span class="range-value" id="hpSpentAPRangeValue">0</span>
                 </div>
             </div>
             <div class="form-group">
                 <label>{{localize "MEGS.HPSpent"}} - {{localize "MEGS.Effect"}}</label>
                 <div class="flexrow">
-                    <input type="range" name="hpSpentEV" value="0" min="0" max="{{maxHpToSpend}}" step="1" oninput="hpSpentEPRangeValue.innerText = this.value">
+                    <input type="range" name="hpSpentEV" value="0" min="0" max="{{maxHpToSpend}}" step="1" data-readout="hpSpentEPRangeValue">
                     <span class="range-value" id="hpSpentEPRangeValue">0</span>
                 </div>
             </div>
             <div class="form-group">
                 <label>{{localize "MEGS.HPSpent"}} - {{localize "MEGS.Opposing"}}</label>
                 <div class="flexrow">
-                    <input type="range" name="hpSpentOV" value="0" min="0" max="100" step="1" oninput="hpSpentOVRangeValue.innerText = this.value">
+                    <input type="range" name="hpSpentOV" value="0" min="0" max="100" step="1" data-readout="hpSpentOVRangeValue">
                     <span class="range-value" id="hpSpentOVRangeValue">0</span>
                 </div>
             </div>
             <div class="form-group">
                 <label>{{localize "MEGS.HPSpent"}} - {{localize "MEGS.Resistance"}}</label>
                 <div class="flexrow">
-                    <input type="range" name="hpSpentRV" value="0" min="0" max="100" step="1" oninput="hpSpentRVRangeValue.innerText = this.value">
+                    <input type="range" name="hpSpentRV" value="0" min="0" max="100" step="1" data-readout="hpSpentRVRangeValue">
                     <span class="range-value" id="hpSpentRVRangeValue">0</span>
                 </div>
             </div>

--- a/templates/partials/plusMinusInput.hbs
+++ b/templates/partials/plusMinusInput.hbs
@@ -1,6 +1,7 @@
-<!-- TODO not being used -->
-<div class='quantity {{classes}}'>
-    <button class='minus' aria-label='Decrease' onClick='if (parseInt({{id}}Input.value) > {{min}})  {{id}}Input.value = parseInt({{id}}Input.value) - 1'>&minus;</button>
+<!-- TODO not being used -- the live partial is registered in module/megs.mjs. -->
+<!-- Behaviour is attached by activateStepperControls(); see module/helpers/dialog-controls.mjs. -->
+<div class='quantity {{classes}}' data-control='stepper'>
+    <button type='button' class='minus' data-step='-1' aria-label='Decrease'>&minus;</button>
     <input id='{{id}}Input' name='system.{{id}}' type='number' class='input-box' value='{{value}}' min='{{min}}' max='{{max}}' data-dtype='Number' />
-    <button class='plus' aria-label='Increase' onClick='{{id}}Input.value = parseInt({{id}}Input.value)+ 1 '>&plus;</button>
+    <button type='button' class='plus' data-step='1' aria-label='Increase'>&plus;</button>
 </div>


### PR DESCRIPTION
Fixes #275

## The bug

Foundry v14's `DialogV2._initializeApplicationOptions` runs string `content` through `foundry.utils.cleanHTML()`, an allow-list sanitizer that strips every inline `on*` attribute. The roll dialog's controls were built entirely on inline handlers, so on v14:

- The `-` / `+` buttons beside Action, Effect, Opposing and Resistance Value have no `type`, so they default to `type="submit"`. With their `onclick` stripped they submit the DialogV2 form — **clicking one closes the dialog and discards the roll** instead of changing the value.
- The number beside each Hero Point slider never moves off `0`. The hero points *were* being applied (dragging the AV slider to 8 drops an AV 5 vs OV 5 roll from difficulty 11 to 4), but nothing on screen said so, which is what the bug was reported as.
- The initiative dialog's slider readout is dead for the same reason.

ApplicationV1 sheets never pass through `cleanHTML`, which is why the character sheet was unaffected and the problem looked confined to rolling.

## The fix

Dialog markup can no longer carry its own behaviour, so it is attached after render:

- New `module/helpers/dialog-controls.mjs` wires `[data-control="stepper"]` groups and `input[type="range"][data-readout]` elements. Both bind on explicit `data-` attributes rather than class names, so they attach only to markup written for them — the sheet templates that still use inline handlers are ApplicationV1, are never sanitized, and must not also be driven from here or every click would count twice.
- The roll and initiative dialogs call it from a DialogV2 `render` callback.
- The `-` / `+` buttons are now `type="button"`, so they cannot submit the dialog even if their handler ever fails to attach again.
- The `plusMinusInput` partial (built in `module/megs.mjs`, not the dead `.hbs`) renders in both dialogs and sheets, so it lost its inline handlers too and the sheets now wire it explicitly in `activateListeners`.
- Stepping now respects the field's own `min`/`max`. The old inline handler ignored `min` entirely.

## Also added

The dialog now shows how many Hero Points the character has, and says so explicitly when there are none. A character with 0 hero points gets `max="0"` sliders that genuinely cannot move — correct, but previously unexplained, and part of why the reporter thought the feature was broken.

## Deliberately not changed

- **OV/RV sliders keep `max="100"`.** The issue flags them as inconsistent with the AV/EV cap, and they are — but hero points spent on OV/RV represent the *defender* resisting, not the roller acting, so capping them at the roller's pool would be wrong. This needs a rules decision rather than a code tweak, so it is left alone.
- **`dice.mjs` HP-deduction TODO.** Spent hero points are still not deducted from the actor. Out of scope for this regression.

## Testing

- 5 new E2E tests drive the controls the way a player does — real clicks and a real pointer drag. Every existing spec sets `.value` directly, which is why none of them could see this class of failure.
- 9 new unit tests for the stepper bounds arithmetic.
- Both suites were proven able to fail: removing the `render` callback fails the three behaviour tests (AV stays 8 after clicking `+`) while the two template-only tests correctly stay green; mutating the bounds handling fails the unit tests for the right reasons.
- Jest 137 passed / 1 todo. Lint clean.
- Full Playwright suite: **162 passed, 0 failed, 0 skipped** (27.1m). One flaky: `accordion-state` test #1 timed out in the worker fixture at `game.ready` — before any MEGS code loads — and passed on retry in the same run and 3/3 in isolation afterwards. That is the single-Gamemaster-seat contention from my own back-to-back screenshot runs, not this change.

## Before / after

Both screenshots show the AV hero-point slider dragged fully to the right (value 8).

Before: readout stuck on `0`.
After: readout shows `8`, plus the new "Hero Points available" line.

Screenshots are at `docs/screenshots/275-roll-dialog-before.png` and `275-roll-dialog-after.png` — that directory is gitignored, so they are not in the diff.
