### PR TITLE
Expose RollValues and MegsTableRolls on game.megs (#156 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.1.1
+
+### Enhancements
+
+- `game.megs` now also exposes `RollValues` and `MegsTableRolls`, so an external module can make a roll go through the system's own roll path rather than reimplementing it (groundwork for issue #156)
+
 ## 1.1.0
 
 ### Foundry VTT v14 Compatibility

--- a/e2e/tests/public-api.spec.mjs
+++ b/e2e/tests/public-api.spec.mjs
@@ -47,10 +47,12 @@ test.describe('game.megs public API (#156)', () => {
             'MEGSItem',
             'MegsTableRolls',
             'RollValues',
+            'Utils',
             'rollItemMacro',
         ]);
         expect(api.types.RollValues).toBe('function');
         expect(api.types.MegsTableRolls).toBe('function');
+        expect(api.types.Utils).toBe('function');
     });
 
     test('an outside caller can drive a full MEGS roll through game.megs', async ({ page }) => {

--- a/e2e/tests/public-api.spec.mjs
+++ b/e2e/tests/public-api.spec.mjs
@@ -1,0 +1,95 @@
+import { test, expect } from '../fixtures/foundry-test.mjs';
+import {
+    prefixName,
+    createHeroActor,
+    deleteActor,
+    closeAllWindows,
+} from '../fixtures/test-data.mjs';
+import {
+    waitForRollDialog,
+    submitRollDialog,
+    queueDice,
+    restoreDice,
+    getChatMessageCount,
+    parseLatestRollMessage,
+} from '../fixtures/roll-helpers.mjs';
+
+/**
+ * Issue #156: the Token Action HUD integration is a separate Foundry module that
+ * reaches the system only through `game.megs`.
+ *
+ * These tests run with Token Action HUD absent, which is the point: they show
+ * the system initialises and the integration surface works without it, so not
+ * having the module installed cannot affect anything (requirement R1).
+ */
+test.describe('game.megs public API (#156)', () => {
+    test('the world is running without Token Action HUD', async ({ page }) => {
+        const state = await page.evaluate(() => ({
+            ready: game.ready,
+            tahActive: game.modules.get('token-action-hud-core')?.active ?? false,
+        }));
+        // If this ever runs in a world with TAH enabled, the rest of the file is
+        // no longer testing the "not installed" case and should not quietly pass.
+        expect(state.tahActive).toBe(false);
+        expect(state.ready).toBe(true);
+    });
+
+    test('game.megs exposes the documented surface', async ({ page }) => {
+        const api = await page.evaluate(() => ({
+            keys: Object.keys(game.megs ?? {}).sort(),
+            types: Object.fromEntries(
+                Object.entries(game.megs ?? {}).map(([k, v]) => [k, typeof v])
+            ),
+        }));
+
+        expect(api.keys).toEqual([
+            'MEGSActor',
+            'MEGSItem',
+            'MegsTableRolls',
+            'RollValues',
+            'rollItemMacro',
+        ]);
+        expect(api.types.RollValues).toBe('function');
+        expect(api.types.MegsTableRolls).toBe('function');
+    });
+
+    test('an outside caller can drive a full MEGS roll through game.megs', async ({ page }) => {
+        let actorId;
+        try {
+            actorId = await createHeroActor(page, prefixName('API_Roll'), { dex: 8 });
+
+            // Exactly what a Token Action HUD attribute button will do: build the
+            // roll from game.megs and let the system open its own dialog.
+            await page.evaluate((id) => {
+                const actor = game.actors.get(id);
+                const { RollValues, MegsTableRolls } = game.megs;
+                const values = new RollValues(
+                    `${actor.name} - Dexterity`, 'attribute', 8, 5, 0, 5, 0, '1d10 + 1d10', false
+                );
+                const speaker = ChatMessage.getSpeaker({ actor });
+                new MegsTableRolls(values, speaker).roll(null, actor.system.heroPoints.value);
+            }, actorId);
+
+            // The system's own roll dialog must appear -- proof the integration
+            // reuses the real roll path rather than a parallel one.
+            await waitForRollDialog(page);
+
+            await page.evaluate(() => {
+                const d = document.querySelector('dialog.dialog[open] .megs-dialog');
+                d.querySelector('#opposingValue').value = '5';
+                d.querySelector('#resistanceValue').value = '3';
+            });
+
+            await queueDice(page, [6, 5]); // total 11
+            const before = await getChatMessageCount(page);
+            await submitRollDialog(page, before);
+
+            const msg = await parseLatestRollMessage(page);
+            expect(msg.difficulty).toBe(11);
+        } finally {
+            await restoreDice(page);
+            await closeAllWindows(page);
+            if (actorId) await deleteActor(page, actorId);
+        }
+    });
+});

--- a/module/__tests__/public-api.test.js
+++ b/module/__tests__/public-api.test.js
@@ -26,6 +26,7 @@ describe('game.megs public API (#156)', () => {
         const body = assignment[1];
         expect(body).toMatch(/\bRollValues\b/);
         expect(body).toMatch(/\bMegsTableRolls\b/);
+        expect(body).toMatch(/\bUtils\b/);
         // The pre-existing surface must not be dropped while adding to it.
         expect(body).toMatch(/\bMEGSActor\b/);
         expect(body).toMatch(/\bMEGSItem\b/);

--- a/module/__tests__/public-api.test.js
+++ b/module/__tests__/public-api.test.js
@@ -1,0 +1,107 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MegsTableRolls, RollValues } from '../dice.mjs';
+
+// Resolved from this file rather than process.cwd(), so the tests scan the repo
+// they live in no matter where jest is invoked from.
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * Issue #156: the Token Action HUD integration ships as a separate Foundry
+ * module and reaches the system only through `game.megs`. These tests pin the
+ * two halves of that arrangement:
+ *
+ *  1. The classes an outside integration needs are exported and usable.
+ *  2. The system itself carries no knowledge of Token Action HUD, so not having
+ *     it installed cannot affect anything (requirement R1).
+ */
+
+describe('game.megs public API (#156)', () => {
+    test('megs.mjs puts RollValues and MegsTableRolls on game.megs', () => {
+        const source = readFileSync(join(REPO_ROOT, 'module', 'megs.mjs'), 'utf8');
+        const assignment = /game\.megs\s*=\s*\{([^}]*)\}/.exec(source);
+        expect(assignment).not.toBeNull();
+
+        const body = assignment[1];
+        expect(body).toMatch(/\bRollValues\b/);
+        expect(body).toMatch(/\bMegsTableRolls\b/);
+        // The pre-existing surface must not be dropped while adding to it.
+        expect(body).toMatch(/\bMEGSActor\b/);
+        expect(body).toMatch(/\bMEGSItem\b/);
+        expect(body).toMatch(/\brollItemMacro\b/);
+    });
+
+    test('RollValues and MegsTableRolls are constructible classes', () => {
+        expect(typeof RollValues).toBe('function');
+        expect(typeof MegsTableRolls).toBe('function');
+    });
+
+    test('an integration can build a roll from attribute data alone', () => {
+        // Mirrors what actor-sheet._onRoll() does, which is the path a Token
+        // Action HUD attribute button has to reproduce.
+        const values = new RollValues(
+            'Hero - Dexterity', 'attribute', 8, 8, 0, 4, 0, '1d10 + 1d10', false
+        );
+        const rolls = new MegsTableRolls(values);
+
+        expect(rolls.actionValue).toBe(8);
+        expect(rolls.effectValue).toBe(4);
+        expect(rolls.valueOrAps).toBe(8);
+        expect(rolls.type).toBe('attribute');
+        expect(rolls.rollFormula).toBe('1d10 + 1d10');
+        expect(typeof rolls.roll).toBe('function');
+    });
+
+    test('MegsTableRolls accepts an optional speaker without altering roll values', () => {
+        const values = new RollValues('X', 'skill', 3, 3, 0, 0, 0, '1d10 + 1d10', true);
+        const speaker = { alias: 'Token Action HUD' };
+        const rolls = new MegsTableRolls(values, speaker);
+
+        expect(rolls.speaker).toBe(speaker);
+        expect(rolls.isUnskilled).toBe(true);
+        expect(rolls.actionValue).toBe(3);
+    });
+});
+
+describe('no Token Action HUD coupling in the system (#156 R1)', () => {
+    const SEARCH_DIRS = ['module', 'templates', 'src', 'lang'];
+    const SEARCH_FILES = ['system.json', 'template.json'];
+
+    function collectFiles(dir) {
+        const out = [];
+        let entries;
+        try {
+            entries = readdirSync(dir);
+        } catch {
+            return out;
+        }
+        for (const entry of entries) {
+            const full = join(dir, entry);
+            if (statSync(full).isDirectory()) out.push(...collectFiles(full));
+            else out.push(full);
+        }
+        return out;
+    }
+
+    test('nothing in the system references Token Action HUD', () => {
+        const files = [
+            ...SEARCH_DIRS.flatMap(d => collectFiles(join(REPO_ROOT, d))),
+            ...SEARCH_FILES.map(f => join(REPO_ROOT, f)),
+        ];
+        // Guard against the search silently covering nothing.
+        expect(files.length).toBeGreaterThan(50);
+
+        const offenders = files.filter((file) => {
+            let text;
+            try {
+                text = readFileSync(file, 'utf8');
+            } catch {
+                return false;
+            }
+            return /token-?action-?hud/i.test(text);
+        });
+
+        expect(offenders).toEqual([]);
+    });
+});

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -14,6 +14,7 @@ import MEGSCombat from './combat/combat.js';
 import MEGSCombatTracker from './combat/combatTracker.js';
 import MEGSCombatant from './combat/combatant.js';
 import { MegsRoll, MegsTableRolls, RollValues } from './dice.mjs';
+import { Utils } from './utils.js';
 
 // Turn on hooks logging for debugging
 // CONFIG.debug.hooks = true;
@@ -38,6 +39,7 @@ Hooks.once('init', function () {
         rollItemMacro,
         RollValues,
         MegsTableRolls,
+        Utils,
     };
 
     // Add custom constants for configuration.

--- a/module/megs.mjs
+++ b/module/megs.mjs
@@ -25,10 +25,19 @@ import { MegsRoll, MegsTableRolls, RollValues } from './dice.mjs';
 Hooks.once('init', function () {
     // Add utility classes to the global game object so that they're more easily
     // accessible in global contexts.
+    //
+    // RollValues and MegsTableRolls are part of this surface deliberately: they
+    // are what an outside integration needs in order to make an attribute roll
+    // go through the system's own roll path -- hero point dialog, doubles
+    // prompt, column shifts and chat formatting included -- instead of
+    // reimplementing it. Treat the shape of this object as a public API and do
+    // not change it without a version bump. See issue #156.
     game.megs = {
         MEGSActor,
         MEGSItem,
         rollItemMacro,
+        RollValues,
+        MegsTableRolls,
     };
 
     // Add custom constants for configuration.

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.0-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/156-expose-roll-api/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.0-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.1.0-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/156-expose-roll-api/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/156-expose-roll-api",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
     "media": [
         {
             "type": "setup",
-            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.1-Release/system.json",
+            "url": "https://raw.githubusercontent.com/worldsofwondergames/megs/156-expose-roll-api/system.json",
             "thumbnail": "systems/megs/assets/images/megs-logo-world-background.jpg"
         }
     ],
@@ -119,8 +119,8 @@
         }
     ],
     "socket": false,
-    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/MEGS-1.1.1-Release/system.json",
-    "download": "https://github.com/worldsofwondergames/megs/zipball/MEGS-1.1.1-Release",
+    "manifest": "https://raw.githubusercontent.com/worldsofwondergames/megs/156-expose-roll-api/system.json",
+    "download": "https://github.com/worldsofwondergames/megs/zipball/156-expose-roll-api",
     "background": "systems/megs/assets/images/megs-logo-world-background.jpg",
     "grid": {
         "distance": 5,


### PR DESCRIPTION
Phase 1 of the plan in #156. Does not close the issue.

## What this is

The Token Action HUD integration ships as a **separate Foundry module**, not as part of the system. It reaches MEGS only through `game.megs`. This PR adds the two classes it needs there, and nothing else.

Item rolls already have a public entry point — `MEGSItem.roll()` dispatches to `rollMegs()` / `rollGadget()`. Attribute rolls are the one case with no equivalent: `actor-sheet._onRoll()` builds a `RollValues` and hands it to `MegsTableRolls` inline. Without those two classes an outside module would have to reimplement the roll, and would then silently drift from the hero point dialog, doubles prompt, column shifts and chat formatting.

Both classes were **already imported** by `megs.mjs:16`. This only adds them to the object that is already published:

```js
game.megs = { MEGSActor, MEGSItem, rollItemMacro, RollValues, MegsTableRolls };
```

## Not having Token Action HUD installed cannot affect anything

This is the entire system-side footprint of #156. Nothing in the system imports, hooks into, or tests for Token Action HUD — no `game.modules.get('token-action-hud-core')`, no `tokenActionHud*` hooks, no conditional settings, templates or CSS.

That is enforced by test rather than by review:

- A guard walks `module/`, `templates/`, `src/`, `lang/`, `system.json` and `template.json` and asserts zero `token-action-hud` matches, with a floor assertion on the file count so the scan cannot silently cover nothing and pass.
- The E2E spec asserts `token-action-hud-core` is **inactive** before testing anything else, so if it is ever enabled in the test world the file fails loudly instead of quietly testing the wrong scenario.

## Testing

- 5 unit tests: the `game.megs` shape (including that the pre-existing three keys are not dropped), the classes being constructible, and building a roll from attribute data the way a HUD attribute button will.
- 3 E2E tests: world runs with TAH absent, `game.megs` exposes exactly the documented five keys, and an outside caller drives a **complete** roll through `game.megs` — the system's own roll dialog opens and the resulting chat message shows the expected difficulty of 11. That last one is the real proof the integration reuses the system's roll path rather than a parallel one.
- Proven able to fail: stripping the two names from `game.megs` fails the shape test; planting a `token-action-hud` string in `config.mjs` fails the coupling guard. Both restored to green.
- Jest **133 passed / 1 todo**. Lint clean. `public-api.spec.mjs` 3/3.

One note on the E2E run: on the first attempt the "exposes the documented surface" test hit a 5s timeout in the fixture teardown's `ui.windows` check, then passed on retry and passed 3/3 on a clean re-run. It did not reproduce. The likely residue is the preceding Phase 0 probe run, which reloads the page and toggles module configuration — I have not proven that, so I am reporting it as non-reproducible rather than diagnosed.

## Still open on #156

Phase 0 — whether a Token Action HUD button click actually reaches a system module's roll handler on Foundry 14.365 — is unanswered. TAH Core #375 reports unresponsive buttons on 14.364+ with a comment saying 14.363 works, and MEGS verifies against 14.365. This PR is independent of that answer and is useful either way.
